### PR TITLE
Basic conversion functionality (task #2011)

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -41,6 +41,16 @@ trait ConfigurationTrait
     protected $_moduleAlias;
 
     /**
+     * Method that returns table configuration.
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        return $this->_config;
+    }
+
+    /**
      * Method that sets table configuration.
      *
      * @return void

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -2,6 +2,7 @@
 namespace CsvMigrations\Controller;
 
 use App\Controller\AppController as BaseController;
+use Cake\ORM\TableRegistry;
 
 class AppController extends BaseController
 {
@@ -63,12 +64,35 @@ class AppController extends BaseController
         if ($this->request->is('post')) {
             $entity = $this->{$this->name}->patchEntity($entity, $this->request->data);
             if ($this->{$this->name}->save($entity)) {
+                /**
+                 * Conversion logic
+                 * @todo probably this has to be moved to another plugin
+                 */
+                if (!empty($this->request->data['convFrom'])) {
+                    $convFrom = $this->request->data['convFrom'];
+                    $convFromTable = TableRegistry::get($convFrom['model']);
+                    $convFromEntity = $convFromTable->get($convFrom['id']);
+                    $convData = [$convFrom['field'] => $convFrom['value']];
+
+                    $convFromEntity = $convFromTable->patchEntity($convFromEntity, $convData);
+                    $convFromTable->save($convFromEntity);
+                }
+
                 $this->Flash->success(__('The record has been saved.'));
                 return $this->redirect(['action' => 'index']);
             } else {
                 $this->Flash->error(__('The record could not be saved. Please, try again.'));
             }
         }
+        /**
+         * Conversion logic
+         * @todo probably this has to be moved to another plugin
+         */
+        if (!empty($this->request->params['convert'])) {
+            $this->request->data = $this->request->params['convert']['data'];
+            $this->set('convFrom', $this->request->params['convert']['from']);
+        }
+
         $this->set(compact('entity'));
         $this->render('CsvMigrations.Common/add');
         $this->set('_serialize', ['entity']);

--- a/src/Template/Element/View/add.ctp
+++ b/src/Template/Element/View/add.ctp
@@ -53,6 +53,18 @@ if (!empty($this->request->query['embedded'])) {
         <fieldset>
             <legend><?= $options['title'] ?></legend>
             <?php
+                /**
+                 * Conversion logic
+                 * @todo probably this has to be moved to another plugin
+                 */
+                if (!empty($convFrom)) {
+                    echo $this->Form->hidden('convFrom.model', ['value' => $convFrom['model']]);
+                    echo $this->Form->hidden('convFrom.id', ['value' => $convFrom['id']]);
+                    echo $this->Form->hidden('convFrom.field', ['value' => $convFrom['field']]);
+                    echo $this->Form->hidden('convFrom.value', ['value' => $convFrom['value']]);
+                }
+            ?>
+            <?php
                 if (!empty($options['fields'])) {
                     $embeddedFields = [];
                     $embeddedDirty = false;


### PR DESCRIPTION
Supports converting one module to another. Field and value of the "convert from" module changes to pre-defined settings. Newly created record is also linked back to the converted record.

Example configuration data (Leads module):
```ini
# config/CsvMigrations/migrations/Leads/config.ini
[conversion]
modules = CrmRe.Opportunities
field = status
value = converted
```