### PR TITLE
Re-factoring (task #2042)

### DIFF
--- a/src/CsvMigration.php
+++ b/src/CsvMigration.php
@@ -161,7 +161,7 @@ class CsvMigration extends AbstractMigration
     protected function _createFromCsv(array $csvData)
     {
         foreach ($csvData as $col) {
-            $field = $this->_fhf->convertField($col);
+            $field = $this->_fhf->fieldToDb($col);
 
             $this->_table->addColumn($field['name'], $field['type'], [
                 'limit' => $field['limit'],
@@ -194,7 +194,7 @@ class CsvMigration extends AbstractMigration
             if (!in_array($tableFieldName, array_keys($csvData))) {
                 $this->_table->removeColumn($tableFieldName);
             } else {
-                $field = $this->_fhf->convertField($csvData[$tableFieldName]);
+                $field = $this->_fhf->fieldToDb($csvData[$tableFieldName]);
 
                 $this->_table->changeColumn($field['name'], $field['type'], [
                     'limit' => $field['limit'],

--- a/src/CsvTrait.php
+++ b/src/CsvTrait.php
@@ -1,0 +1,53 @@
+<?php
+namespace CsvMigrations;
+
+use Cake\Core\Configure;
+
+trait CsvTrait
+{
+    /**
+     * Method that restructures csv data for better handling and searching through.
+     *
+     * @param  array  $csvData csv data
+     * @return array
+     */
+    protected function _prepareCsvData(array $csvData)
+    {
+        $result = [];
+        foreach ($csvData as $col) {
+            $col += array_values($this->_defaultParams);
+            $result[$col[0]] = array_combine(array_keys($this->_defaultParams), $col);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Method that retrieves csv file data.
+     *
+     * @param  string $path     csv file path
+     * @param  array  $skipRows which rows to skip
+     * @return array            csv data
+     * @todo this method should be moved to a Trait class as is used throught Csv Migrations and Csv Views plugins
+     */
+    protected function _getCsvData($path, array $skipRows = [0])
+    {
+        $result = [];
+        if (file_exists($path)) {
+            if (false !== ($handle = fopen($path, 'r'))) {
+                $row = 0;
+                while (false !== ($data = fgetcsv($handle, 0, ','))) {
+                    // skip first row
+                    if (in_array($row, $skipRows)) {
+                        $row++;
+                        continue;
+                    }
+                    $result[] = $data;
+                }
+                fclose($handle);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/CsvTrait.php
+++ b/src/CsvTrait.php
@@ -43,20 +43,19 @@ trait CsvTrait
     /**
      * Method that retrieves csv file data.
      *
-     * @param  string $path     csv file path
-     * @param  array  $skipRows which rows to skip
-     * @return array            csv data
-     * @todo this method should be moved to a Trait class as is used throught Csv Migrations and Csv Views plugins
+     * @param  string $path        csv file path
+     * @param  array  $skipHeaders skip csv headers flag
+     * @return array               csv data
      */
-    protected function _getCsvData($path, array $skipRows = [0])
+    protected function _getCsvData($path, $skipHeaders = true)
     {
         $result = [];
         if (file_exists($path)) {
             if (false !== ($handle = fopen($path, 'r'))) {
                 $row = 0;
                 while (false !== ($data = fgetcsv($handle, 0, ','))) {
-                    // skip first row
-                    if (in_array($row, $skipRows)) {
+                    // skip csv headers
+                    if ($skipHeaders && 0 === $row) {
                         $row++;
                         continue;
                     }

--- a/src/CsvTrait.php
+++ b/src/CsvTrait.php
@@ -6,6 +6,17 @@ use Cake\Core\Configure;
 trait CsvTrait
 {
     /**
+     * Field parameters. Order is important.
+     * @var array
+     */
+    private $__defaultParams = [
+        'name' => '',
+        'type' => '',
+        'required' => '',
+        'non-searchable' => ''
+    ];
+
+    /**
      * Method that restructures csv data for better handling and searching through.
      *
      * @param  array  $csvData csv data
@@ -15,8 +26,15 @@ trait CsvTrait
     {
         $result = [];
         foreach ($csvData as $col) {
-            $col += array_values($this->_defaultParams);
-            $result[$col[0]] = array_combine(array_keys($this->_defaultParams), $col);
+            $fields = array_keys($this->__defaultParams);
+            $namedCol = array();
+            foreach ($fields as $i => $field) {
+                if (!empty($col[$i])) {
+                    $namedCol[$field] = $col[$i];
+                }
+            }
+            $namedCol = array_merge($this->__defaultParams, $namedCol);
+            $result[$namedCol['name']] = $namedCol;
         }
 
         return $result;

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -61,6 +61,17 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
     }
 
     /**
+     * Method responsible for converting field for migration.
+     *
+     * @param  string $field field name
+     * @return array         converted field
+     */
+    public function convertField($field)
+    {
+        return $field;
+    }
+
+    /**
      * Method that generates field name based on its options.
      *
      * @param  \Cake\ORM\Table $table Table instance

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -2,6 +2,8 @@
 namespace CsvMigrations\FieldHandlers;
 
 use App\View\AppView;
+use CsvMigrations\FieldHandlers\CsvField;
+use CsvMigrations\FieldHandlers\DbField;
 use CsvMigrations\FieldHandlers\FieldHandlerInterface;
 
 abstract class BaseFieldHandler implements FieldHandlerInterface
@@ -61,16 +63,22 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
     }
 
     /**
-     * Method responsible for converting field for migration.
+     * Method responsible for converting csv field instance to database field instance.
      *
-     * @param  string $field field name
-     * @return array         converted field
+     * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
+     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
      */
-    public function fieldToDb($field)
+    public function fieldToDb(CsvField $csvField)
     {
-        $field['type'] = preg_replace(static::FIELD_TYPE_PATTERN, '', $field['type']);
+        $dbField = new DbField(
+            $csvField->getName(),
+            $csvField->getType(),
+            $csvField->getLimit(),
+            $csvField->getRequired(),
+            $csvField->getNonSearchable()
+        );
 
-        return $field;
+        return $dbField;
     }
 
     /**

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -7,11 +7,6 @@ use CsvMigrations\FieldHandlers\FieldHandlerInterface;
 abstract class BaseFieldHandler implements FieldHandlerInterface
 {
     /**
-     * Field type match pattern
-     */
-    const FIELD_TYPE_PATTERN = '/\(.*?\)/';
-
-    /**
      * Csv field types respective input field types
      * @var array
      */

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -66,11 +66,11 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
      * Method responsible for converting csv field instance to database field instance.
      *
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
-     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
+     * @return array list of DbField instances
      */
     public function fieldToDb(CsvField $csvField)
     {
-        $dbField = new DbField(
+        $dbFields[] = new DbField(
             $csvField->getName(),
             $csvField->getType(),
             $csvField->getLimit(),
@@ -78,7 +78,7 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
             $csvField->getNonSearchable()
         );
 
-        return $dbField;
+        return $dbFields;
     }
 
     /**

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -7,6 +7,11 @@ use CsvMigrations\FieldHandlers\FieldHandlerInterface;
 abstract class BaseFieldHandler implements FieldHandlerInterface
 {
     /**
+     * Field type match pattern
+     */
+    const FIELD_TYPE_PATTERN = '/\(.*?\)/';
+
+    /**
      * Csv field types respective input field types
      * @var array
      */
@@ -68,6 +73,8 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
      */
     public function fieldToDb($field)
     {
+        $field['type'] = preg_replace(static::FIELD_TYPE_PATTERN, '', $field['type']);
+
         return $field;
     }
 

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -66,7 +66,7 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
      * @param  string $field field name
      * @return array         converted field
      */
-    public function convertField($field)
+    public function fieldToDb($field)
     {
         return $field;
     }

--- a/src/FieldHandlers/CsvField.php
+++ b/src/FieldHandlers/CsvField.php
@@ -1,6 +1,7 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
+use CsvMigrations\FieldHandlers\FieldHandlerFactory;
 use InvalidArgumentException;
 
 class CsvField
@@ -176,7 +177,7 @@ class CsvField
 
         $type = $this->_extractType($type);
 
-        if (!in_array($type, $this->_supportedTypes)) {
+        if (!in_array($type, FieldHandlerFactory::getList())) {
             throw new InvalidArgumentException('Unsupported field type: ' . $type);
         }
 

--- a/src/FieldHandlers/CsvField.php
+++ b/src/FieldHandlers/CsvField.php
@@ -1,0 +1,213 @@
+<?php
+namespace CsvMigrations\FieldHandlers;
+
+use InvalidArgumentException;
+
+class CsvField
+{
+    const PATTERN_TYPE = '/(.*?)\((.*?)\)/';
+
+    /**
+     * field name
+     *
+     * @var string
+     */
+    protected $_name;
+
+    /**
+     * field type
+     *
+     * @var string
+     */
+    protected $_type;
+
+    /**
+     * field limit
+     *
+     * @var int
+     */
+    protected $_limit;
+
+    /**
+     * field required flag
+     *
+     * @var bool
+     */
+    protected $_required;
+
+    /**
+     * field non-searchable flag
+     *
+     * @var bool
+     */
+    protected $_nonSearchable;
+
+    /**
+     * Supported field types
+     *
+     * @var array
+     */
+    protected $_supportedTypes = [
+        'uuid',
+        'string',
+        'integer',
+        'boolean',
+        'text',
+        'datetime',
+        'date',
+        'time',
+        'list',
+        'related',
+        'file'
+    ];
+
+    /**
+     * Constructor
+     *
+     * @param string $name          field name
+     * @param string $type          field type
+     * @param string $required      field required flag
+     * @param string $nonSearchable field non-searchable flag
+     */
+    public function __construct($name, $type, $required, $nonSearchable)
+    {
+        list($type, $limit) = $this->_extractTypeAndLimit($type);
+        $this->setName($name);
+        $this->setType($type);
+        $this->setLimit($limit);
+        $this->setRequired($required);
+        $this->setNonSearchable($nonSearchable);
+
+    }
+
+    /**
+     * Extract field type and limit from type value.
+     *
+     * @param  string $type field type
+     * @return array        field type and limit
+     */
+    protected function _extractTypeAndLimit($type)
+    {
+        if (false !== strpos($type, '(')) {
+            preg_match(static::PATTERN_TYPE, $type, $matches);
+            $type = $matches[1];
+            $limit = $matches[2];
+        } else {
+            $limit = null;
+        }
+
+        return [$type, $limit];
+    }
+
+    /**
+     * Field name setter.
+     *
+     * @param string $name field name
+     */
+    public function setName($name)
+    {
+        if (empty($name)) {
+            throw new InvalidArgumentException('Empty field name is not allowed');
+        }
+
+        $this->_name = $name;
+    }
+
+    /**
+     * Field name getter.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->_name;
+    }
+
+    /**
+     * Field type setter.
+     *
+     * @param string $type field type
+     */
+    public function setType($type)
+    {
+        if (empty($type)) {
+            throw new InvalidArgumentException('Empty field type is not allowed: ' . $this->getName());
+        }
+
+        if (!in_array($type, $this->_supportedTypes)) {
+            throw new InvalidArgumentException('Unsupported field type: ' . $type);
+        }
+
+        $this->_type = $type;
+    }
+
+    /**
+     * Field type getter.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->_type;
+    }
+
+    /**
+     * Field limit setter.
+     *
+     * @param string $limit field limit
+     */
+    public function setLimit($limit)
+    {
+        $this->_limit = (int)$limit;
+    }
+
+    /**
+     * Field limit getter.
+     *
+     * @return int
+     */
+    public function getLimit()
+    {
+        return $this->_limit;
+    }
+
+    /**
+     * Field required flag setter.
+     *
+     * @param string $required field required flag
+     */
+    public function setRequired($required)
+    {
+        $this->_required = (bool)$required;
+    }
+
+    /**
+     * Field required flag getter.
+     *
+     * @return bool
+     */
+    public function getRequired()
+    {
+        return $this->_required;
+    }
+
+    /**
+     * Field non-searchable flag setter.
+     *
+     * @param string $nonSearchable field non-searchable flag
+     */
+    public function setNonSearchable($nonSearchable)
+    {
+        $this->_nonSearchable = (bool)$nonSearchable;
+    }
+
+    /**
+     * Field non-searchable flag getter.
+     *
+     * @return bool
+     */
+    public function getNonSearchable()
+    {
+        return $this->_nonSearchable;
+    }
+}

--- a/src/FieldHandlers/DbField.php
+++ b/src/FieldHandlers/DbField.php
@@ -1,0 +1,178 @@
+<?php
+namespace CsvMigrations\FieldHandlers;
+
+class DbField
+{
+    /**
+     * field name
+     *
+     * @var string
+     */
+    protected $_name;
+
+    /**
+     * field type
+     *
+     * @var string
+     */
+    protected $_type;
+
+    /**
+     * field limit
+     *
+     * @var int
+     */
+    protected $_limit;
+
+    /**
+     * field required flag
+     *
+     * @var bool
+     */
+    protected $_required;
+
+    /**
+     * field non-searchable flag
+     *
+     * @var bool
+     */
+    protected $_nonSearchable;
+
+    /**
+     * Supported field types
+     *
+     * @var array
+     */
+    protected $_supportedTypes = ['uuid', 'string', 'integer', 'boolean', 'text', 'datetime', 'date', 'time'];
+
+    /**
+     * Constructor
+     *
+     * @param string $name          field name
+     * @param string $type          field type
+     * @param int    $limit         field limit
+     * @param bool   $required      field required flag
+     * @param bool   $nonSearchable field non-searchable flag
+     */
+    public function __construct($name, $type, $limit, $required, $nonSearchable)
+    {
+        $this->setName($name);
+        $this->setType($type);
+        $this->setLimit($limit);
+        $this->setRequired($required);
+        $this->setNonSearchable($nonSearchable);
+
+    }
+
+    /**
+     * Field name setter.
+     *
+     * @param string $name field name
+     */
+    public function setName($name)
+    {
+        if (empty($name)) {
+            throw new InvalidArgumentException('Empty field name is not allowed');
+        }
+
+        $this->_name = $name;
+    }
+
+    /**
+     * Field name getter.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->_name;
+    }
+
+    /**
+     * Field type setter.
+     *
+     * @param string $type field type
+     */
+    public function setType($type)
+    {
+        if (empty($type)) {
+            throw new InvalidArgumentException('Empty field type is not allowed');
+        }
+
+        if (!in_array($type, $this->_supportedTypes)) {
+            throw new InvalidArgumentException('Unsupported field type: ' . $type);
+        }
+
+        $this->_type = $type;
+    }
+
+    /**
+     * Field type getter.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->_type;
+    }
+
+    /**
+     * Field limit setter.
+     *
+     * @param int $limit field limit
+     */
+    public function setLimit($limit)
+    {
+        $this->_limit = $limit;
+    }
+
+    /**
+     * Field limit getter.
+     *
+     * @return int
+     */
+    public function getLimit()
+    {
+        return $this->_limit;
+    }
+
+    /**
+     * Field required flag setter.
+     *
+     * @param bool $required field required flag
+     */
+    public function setRequired($required)
+    {
+        $this->_required = $required;
+    }
+
+    /**
+     * Field required flag getter.
+     *
+     * @return bool
+     */
+    public function getRequired()
+    {
+        return $this->_required;
+    }
+
+    /**
+     * Field non-searchable flag setter.
+     *
+     * @param bool $nonSearchable field non-searchable flag
+     */
+    public function setNonSearchable($nonSearchable)
+    {
+        $this->_nonSearchable = $nonSearchable;
+    }
+
+    /**
+     * Field non-searchable flag getter.
+     *
+     * @return bool
+     */
+    public function getNonSearchable()
+    {
+        return $this->_nonSearchable;
+    }
+}

--- a/src/FieldHandlers/DbField.php
+++ b/src/FieldHandlers/DbField.php
@@ -1,6 +1,8 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
+use InvalidArgumentException;
+
 class DbField
 {
     /**

--- a/src/FieldHandlers/DbField.php
+++ b/src/FieldHandlers/DbField.php
@@ -41,13 +41,6 @@ class DbField
     protected $_nonSearchable;
 
     /**
-     * Supported field types
-     *
-     * @var array
-     */
-    protected $_supportedTypes = ['uuid', 'string', 'integer', 'boolean', 'text', 'datetime', 'date', 'time'];
-
-    /**
      * Constructor
      *
      * @param string $name          field name

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -39,10 +39,6 @@ class FieldHandlerFactory
      */
     protected $_tableInstances = [];
 
-    /**     * @var array
-     */
-    protected $_supportedTypes = ['uuid', 'string', 'integer', 'boolean', 'text', 'datetime', 'date', 'time'];
-
     /**
      * Method responsible for rendering field's input.
      *

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -37,6 +37,20 @@ class FieldHandlerFactory
     protected $_tableInstances = [];
 
     /**
+     * Supported field types
+     * @var array
+     */
+    protected $_supportedTypes = ['uuid', 'string', 'integer', 'boolean', 'text', 'datetime', 'date', 'time'];
+
+    /**
+     * Error messages
+     * @var array
+     */
+    protected $_errorMessages = [
+        '_validateField' => 'Field type [%s] not supported'
+    ];
+
+    /**
      * Method responsible for rendering field's input.
      *
      * @param  mixed  $table   name or instance of the Table
@@ -70,6 +84,36 @@ class FieldHandlerFactory
         $handler = $this->_getHandler($options['fieldDefinitions']['type']);
 
         return $handler->renderValue($table, $field, $data, $options);
+    }
+
+    /**
+     * Method responsible for converting field for migration.
+     *
+     * @param  string $field field name
+     * @return array         converted field
+     */
+    public function convertField($field)
+    {
+        $handler = $this->_getHandler($field['type']);
+        $field = $handler->convertField($field);
+        $this->_validateField($field);
+
+        return $field;
+    }
+
+    /**
+     * Validate field.
+     * @param  array $field field info
+     * @throws \RuntimeException when field type is not supported
+     * @return bool
+     */
+    protected function _validateField(array $field)
+    {
+        if (!in_array($field['type'], $this->_supportedTypes)) {
+            throw new \RuntimeException(sprintf($this->_errorMessages[__FUNCTION__], $field['type']));
+        }
+
+        return true;
     }
 
     /**

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -5,6 +5,8 @@ use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use CsvMigrations\FieldHandlers\CsvField;
 use CsvMigrations\ForeignKeysHandler;
+use DirectoryIterator;
+use RegexIterator;
 
 class FieldHandlerFactory
 {
@@ -89,6 +91,26 @@ class FieldHandlerFactory
         $fields = $handler->fieldToDb($csvField);
 
         return $fields;
+    }
+
+    /**
+     * Get field handlers list.
+     *
+     * @return array
+     */
+    public static function getList()
+    {
+        $di = new DirectoryIterator(__DIR__);
+        $pattern = '/^(\w+)' . static::HANDLER_SUFFIX . '.php$/';
+        $ri = new RegexIterator($di, $pattern, RegexIterator::REPLACE);
+        $ri->replacement = '$1';
+
+        $result = [];
+        foreach ($ri as $name) {
+            $result[] = Inflector::underscore($name);
+        }
+
+        return $result;
     }
 
     /**

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -3,6 +3,7 @@ namespace CsvMigrations\FieldHandlers;
 
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use CsvMigrations\FieldHandlers\CsvField;
 use CsvMigrations\ForeignKeysHandler;
 
 class FieldHandlerFactory
@@ -77,17 +78,15 @@ class FieldHandlerFactory
     }
 
     /**
-     * Method responsible for converting field for migration.
+     * Method responsible for converting csv field instance to database field instance.
      *
-     * @param  string $field field name
-     * @return array         converted field
+     * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
+     * @return \CsvMigrations\FieldHandlers\DbFieldld            DbField instance
      */
-    public function fieldToDb($field)
+    public function fieldToDb(CsvField $csvField)
     {
-        $handler = $this->_getHandler($field['type']);
-        $field = $handler->fieldToDb($field);
-
-        $this->_validateField($field);
+        $handler = $this->_getHandler($csvField->getType());
+        $field = $handler->fieldToDb($csvField);
 
         return $field;
     }

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -92,10 +92,11 @@ class FieldHandlerFactory
      * @param  string $field field name
      * @return array         converted field
      */
-    public function convertField($field)
+    public function fieldToDb($field)
     {
         $handler = $this->_getHandler($field['type']);
-        $field = $handler->convertField($field);
+        $field = $handler->fieldToDb($field);
+
         $this->_validateField($field);
 
         return $field;

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -47,7 +47,7 @@ class FieldHandlerFactory
      * @var array
      */
     protected $_errorMessages = [
-        '_validateField' => 'Field type [%s] not supported'
+        '_validateField' => 'Field [%s] type [%s] not supported'
     ];
 
     /**
@@ -110,7 +110,7 @@ class FieldHandlerFactory
     protected function _validateField(array $field)
     {
         if (!in_array($field['type'], $this->_supportedTypes)) {
-            throw new \RuntimeException(sprintf($this->_errorMessages[__FUNCTION__], $field['type']));
+            throw new \RuntimeException(sprintf($this->_errorMessages[__FUNCTION__], $field['name'], $field['type']));
         }
 
         return true;

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -8,11 +8,6 @@ use CsvMigrations\ForeignKeysHandler;
 class FieldHandlerFactory
 {
     /**
-     * Field limit match pattern
-     */
-    const PATTERN_LIMIT = '/\((\d+)\)/';
-
-    /**
      * Default Field Handler class name
      */
     const DEFAULT_HANDLER_CLASS = 'Default';
@@ -41,19 +36,9 @@ class FieldHandlerFactory
      */
     protected $_tableInstances = [];
 
-    /**
-     * Supported field types
-     * @var array
+    /**     * @var array
      */
     protected $_supportedTypes = ['uuid', 'string', 'integer', 'boolean', 'text', 'datetime', 'date', 'time'];
-
-    /**
-     * Error messages
-     * @var array
-     */
-    protected $_errorMessages = [
-        '_validateField' => 'Field [%s] type [%s] not supported'
-    ];
 
     /**
      * Method responsible for rendering field's input.
@@ -105,21 +90,6 @@ class FieldHandlerFactory
         $this->_validateField($field);
 
         return $field;
-    }
-
-    /**
-     * Validate field.
-     * @param  array $field field info
-     * @throws \RuntimeException when field type is not supported
-     * @return bool
-     */
-    protected function _validateField(array $field)
-    {
-        if (!in_array($field['type'], $this->_supportedTypes)) {
-            throw new \RuntimeException(sprintf($this->_errorMessages[__FUNCTION__], $field['name'], $field['type']));
-        }
-
-        return true;
     }
 
     /**

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -8,6 +8,11 @@ use CsvMigrations\ForeignKeysHandler;
 class FieldHandlerFactory
 {
     /**
+     * Field limit match pattern
+     */
+    const PATTERN_LIMIT = '/\((\d+)\)/';
+
+    /**
      * Default Field Handler class name
      */
     const DEFAULT_HANDLER_CLASS = 'Default';
@@ -201,7 +206,7 @@ class FieldHandlerFactory
      * Method that retrieves handler class name based on provided field type.
      * It also handles more advanced field types like foreign key and list fields.
      * Example: if field type is 'string' then 'StringFieldHandler' will be returned.
-     * Example: if field type is 'related:users' then 'RelatedFieldHandler' will be returned.
+     * Example: if field type is 'related(Users)' then 'RelatedFieldHandler' will be returned.
      *
      * @param  string $type field type
      * @param  bool   $fqcn true to use fully-qualified class name
@@ -209,7 +214,7 @@ class FieldHandlerFactory
      */
     protected function _getHandlerByFieldType($type, $fqcn = false)
     {
-        if (false !== $pos = strpos($type, ':')) {
+        if (false !== $pos = strpos($type, '(')) {
             $type = substr($type, 0, $pos);
         }
 

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -81,14 +81,14 @@ class FieldHandlerFactory
      * Method responsible for converting csv field instance to database field instance.
      *
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
-     * @return \CsvMigrations\FieldHandlers\DbFieldld            DbField instance
+     * @return array list of DbField instances
      */
     public function fieldToDb(CsvField $csvField)
     {
         $handler = $this->_getHandler($csvField->getType());
-        $field = $handler->fieldToDb($csvField);
+        $fields = $handler->fieldToDb($csvField);
 
-        return $field;
+        return $fields;
     }
 
     /**

--- a/src/FieldHandlers/FieldHandlerInterface.php
+++ b/src/FieldHandlers/FieldHandlerInterface.php
@@ -31,5 +31,5 @@ interface FieldHandlerInterface
      * @param  string $field field name
      * @return array         converted field
      */
-    public function convertField($field);
+    public function fieldToDb($field);
 }

--- a/src/FieldHandlers/FieldHandlerInterface.php
+++ b/src/FieldHandlers/FieldHandlerInterface.php
@@ -24,4 +24,12 @@ interface FieldHandlerInterface
      * @return string          field value
      */
     public function renderValue($table, $field, $data, array $options = []);
+
+    /**
+     * Method responsible for converting field for migration.
+     *
+     * @param  string $field field name
+     * @return array         converted field
+     */
+    public function convertField($field);
 }

--- a/src/FieldHandlers/FieldHandlerInterface.php
+++ b/src/FieldHandlers/FieldHandlerInterface.php
@@ -1,6 +1,8 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
+use CsvMigrations\FieldHandlers\CsvField;
+
 interface FieldHandlerInterface
 {
     /**
@@ -26,10 +28,10 @@ interface FieldHandlerInterface
     public function renderValue($table, $field, $data, array $options = []);
 
     /**
-     * Method responsible for converting field for migration.
+     * Method responsible for converting csv field instance to database field instance.
      *
-     * @param  string $field field name
-     * @return array         converted field
+     * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
+     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
      */
-    public function fieldToDb($field);
+    public function fieldToDb(CsvField $csvField);
 }

--- a/src/FieldHandlers/FileFieldHandler.php
+++ b/src/FieldHandlers/FileFieldHandler.php
@@ -6,6 +6,10 @@ use CsvMigrations\FieldHandlers\BaseFieldHandler;
 
 class FileFieldHandler extends BaseFieldHandler
 {
+    /**
+     * Field type
+     */
+    const FIELD_TYPE = 'uuid';
 
     /**
      * Defines the layout of the wrapper
@@ -71,5 +75,18 @@ class FileFieldHandler extends BaseFieldHandler
             ['target' => '_blank']
         );
         return $result;
+    }
+
+    /**
+     * Method responsible for converting field for migration.
+     *
+     * @param  string $field field name
+     * @return array         converted field
+     */
+    public function convertField($field)
+    {
+        $field['type'] = static::FIELD_TYPE;
+
+        return $field;
     }
 }

--- a/src/FieldHandlers/FileFieldHandler.php
+++ b/src/FieldHandlers/FileFieldHandler.php
@@ -78,15 +78,21 @@ class FileFieldHandler extends BaseFieldHandler
     }
 
     /**
-     * Method responsible for converting field for migration.
+     * Method responsible for converting csv field instance to database field instance.
      *
-     * @param  string $field field name
-     * @return array         converted field
+     * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
+     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
      */
-    public function fieldToDb($field)
+    public function fieldToDb(CsvField $csvField)
     {
-        $field['type'] = static::FIELD_TYPE;
+        $dbField = new DbField(
+            $csvField->getName(),
+            static::FIELD_TYPE,
+            $csvField->getLimit(),
+            $csvField->getRequired(),
+            $csvField->getNonSearchable()
+        );
 
-        return $field;
+        return $dbField;
     }
 }

--- a/src/FieldHandlers/FileFieldHandler.php
+++ b/src/FieldHandlers/FileFieldHandler.php
@@ -83,7 +83,7 @@ class FileFieldHandler extends BaseFieldHandler
      * @param  string $field field name
      * @return array         converted field
      */
-    public function convertField($field)
+    public function fieldToDb($field)
     {
         $field['type'] = static::FIELD_TYPE;
 

--- a/src/FieldHandlers/FileFieldHandler.php
+++ b/src/FieldHandlers/FileFieldHandler.php
@@ -81,18 +81,18 @@ class FileFieldHandler extends BaseFieldHandler
      * Method responsible for converting csv field instance to database field instance.
      *
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
-     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
+     * @return array list of DbField instances
      */
     public function fieldToDb(CsvField $csvField)
     {
-        $dbField = new DbField(
+        $dbFields[] = new DbField(
             $csvField->getName(),
             static::FIELD_TYPE,
-            $csvField->getLimit(),
+            null,
             $csvField->getRequired(),
             $csvField->getNonSearchable()
         );
 
-        return $dbField;
+        return $dbFields;
     }
 }

--- a/src/FieldHandlers/IntegerFieldHandler.php
+++ b/src/FieldHandlers/IntegerFieldHandler.php
@@ -1,0 +1,8 @@
+<?php
+namespace CsvMigrations\FieldHandlers;
+
+use CsvMigrations\FieldHandlers\BaseFieldHandler;
+
+class IntegerFieldHandler extends BaseFieldHandler
+{
+}

--- a/src/FieldHandlers/ListFieldHandler.php
+++ b/src/FieldHandlers/ListFieldHandler.php
@@ -9,6 +9,11 @@ use CsvMigrations\FieldHandlers\BaseFieldHandler;
 class ListFieldHandler extends BaseFieldHandler
 {
     /**
+     * Field type
+     */
+    const FIELD_TYPE = 'string';
+
+    /**
      * Field type match pattern
      */
     const FIELD_TYPE_PATTERN = 'list:';
@@ -85,6 +90,19 @@ class ListFieldHandler extends BaseFieldHandler
         }
 
         return $result;
+    }
+
+    /**
+     * Method responsible for converting field for migration.
+     *
+     * @param  string $field field name
+     * @return array         converted field
+     */
+    public function convertField($field)
+    {
+        $field['type'] = static::FIELD_TYPE;
+
+        return $field;
     }
 
     /**

--- a/src/FieldHandlers/ListFieldHandler.php
+++ b/src/FieldHandlers/ListFieldHandler.php
@@ -16,7 +16,7 @@ class ListFieldHandler extends BaseFieldHandler
     /**
      * Field type match pattern
      */
-    const FIELD_TYPE_PATTERN = 'list:';
+    const FIELD_TYPE_PATTERN = '/list\((.*?)\)/';
 
     /**
      * Field parameters
@@ -113,7 +113,7 @@ class ListFieldHandler extends BaseFieldHandler
      */
     protected function _getListName($type)
     {
-        $result = str_replace(static::FIELD_TYPE_PATTERN, '', $type);
+        $result = preg_replace(static::FIELD_TYPE_PATTERN, '$1', $type);
 
         return $result;
     }

--- a/src/FieldHandlers/ListFieldHandler.php
+++ b/src/FieldHandlers/ListFieldHandler.php
@@ -96,11 +96,11 @@ class ListFieldHandler extends BaseFieldHandler
      * Method responsible for converting csv field instance to database field instance.
      *
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
-     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
+     * @return array list of DbField instances
      */
     public function fieldToDb(CsvField $csvField)
     {
-        $dbField = new DbField(
+        $dbFields[] = new DbField(
             $csvField->getName(),
             static::FIELD_TYPE,
             null,
@@ -108,7 +108,7 @@ class ListFieldHandler extends BaseFieldHandler
             $csvField->getNonSearchable()
         );
 
-        return $dbField;
+        return $dbFields;
     }
 
     /**

--- a/src/FieldHandlers/ListFieldHandler.php
+++ b/src/FieldHandlers/ListFieldHandler.php
@@ -98,7 +98,7 @@ class ListFieldHandler extends BaseFieldHandler
      * @param  string $field field name
      * @return array         converted field
      */
-    public function convertField($field)
+    public function fieldToDb($field)
     {
         $field['type'] = static::FIELD_TYPE;
 

--- a/src/FieldHandlers/ListFieldHandler.php
+++ b/src/FieldHandlers/ListFieldHandler.php
@@ -93,16 +93,22 @@ class ListFieldHandler extends BaseFieldHandler
     }
 
     /**
-     * Method responsible for converting field for migration.
+     * Method responsible for converting csv field instance to database field instance.
      *
-     * @param  string $field field name
-     * @return array         converted field
+     * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
+     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
      */
-    public function fieldToDb($field)
+    public function fieldToDb(CsvField $csvField)
     {
-        $field['type'] = static::FIELD_TYPE;
+        $dbField = new DbField(
+            $csvField->getName(),
+            static::FIELD_TYPE,
+            null,
+            $csvField->getRequired(),
+            $csvField->getNonSearchable()
+        );
 
-        return $field;
+        return $dbField;
     }
 
     /**

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -148,7 +148,7 @@ class RelatedFieldHandler extends BaseFieldHandler
      * @param  string $field field name
      * @return array         converted field
      */
-    public function convertField($field)
+    public function fieldToDb($field)
     {
         $field['type'] = static::FIELD_TYPE;
 

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -12,6 +12,11 @@ class RelatedFieldHandler extends BaseFieldHandler
     use IdGeneratorTrait;
 
     /**
+     * Field type
+     */
+    const FIELD_TYPE = 'uuid';
+
+    /**
      * Field type match pattern
      */
     const FIELD_TYPE_PATTERN = 'related:';
@@ -135,6 +140,19 @@ class RelatedFieldHandler extends BaseFieldHandler
         );
 
         return $result;
+    }
+
+    /**
+     * Method responsible for converting field for migration.
+     *
+     * @param  string $field field name
+     * @return array         converted field
+     */
+    public function convertField($field)
+    {
+        $field['type'] = static::FIELD_TYPE;
+
+        return $field;
     }
 
     /**

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -146,11 +146,11 @@ class RelatedFieldHandler extends BaseFieldHandler
      * Method responsible for converting csv field instance to database field instance.
      *
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
-     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
+     * @return array list of DbField instances
      */
     public function fieldToDb(CsvField $csvField)
     {
-        $dbField = new DbField(
+        $dbFields[] = new DbField(
             $csvField->getName(),
             static::FIELD_TYPE,
             null,
@@ -158,7 +158,7 @@ class RelatedFieldHandler extends BaseFieldHandler
             $csvField->getNonSearchable()
         );
 
-        return $dbField;
+        return $dbFields;
     }
 
     /**

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -143,16 +143,22 @@ class RelatedFieldHandler extends BaseFieldHandler
     }
 
     /**
-     * Method responsible for converting field for migration.
+     * Method responsible for converting csv field instance to database field instance.
      *
-     * @param  string $field field name
-     * @return array         converted field
+     * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
+     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
      */
-    public function fieldToDb($field)
+    public function fieldToDb(CsvField $csvField)
     {
-        $field['type'] = static::FIELD_TYPE;
+        $dbField = new DbField(
+            $csvField->getName(),
+            static::FIELD_TYPE,
+            null,
+            $csvField->getRequired(),
+            $csvField->getNonSearchable()
+        );
 
-        return $field;
+        return $dbField;
     }
 
     /**

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -19,7 +19,7 @@ class RelatedFieldHandler extends BaseFieldHandler
     /**
      * Field type match pattern
      */
-    const FIELD_TYPE_PATTERN = 'related:';
+    const FIELD_TYPE_PATTERN = '/related\((.*?)\)/';
 
     /**
      * Action name for html link
@@ -163,7 +163,7 @@ class RelatedFieldHandler extends BaseFieldHandler
      */
     protected function _getRelatedName($type)
     {
-        $result = str_replace(static::FIELD_TYPE_PATTERN, '', $type);
+        $result = preg_replace(static::FIELD_TYPE_PATTERN, '$1', $type);
 
         return $result;
     }

--- a/src/FieldHandlers/StringFieldHandler.php
+++ b/src/FieldHandlers/StringFieldHandler.php
@@ -1,0 +1,8 @@
+<?php
+namespace CsvMigrations\FieldHandlers;
+
+use CsvMigrations\FieldHandlers\BaseFieldHandler;
+
+class StringFieldHandler extends BaseFieldHandler
+{
+}

--- a/src/FieldHandlers/TextFieldHandler.php
+++ b/src/FieldHandlers/TextFieldHandler.php
@@ -11,11 +11,11 @@ class TextFieldHandler extends BaseFieldHandler
      * Method responsible for converting csv field instance to database field instance.
      *
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
-     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
+     * @return array list of DbField instances
      */
     public function fieldToDb(CsvField $csvField)
     {
-        $dbField = new DbField(
+        $dbFields[] = new DbField(
             $csvField->getName(),
             $csvField->getType(),
             MysqlAdapter::TEXT_LONG,
@@ -23,6 +23,6 @@ class TextFieldHandler extends BaseFieldHandler
             $csvField->getNonSearchable()
         );
 
-        return $dbField;
+        return $dbFields;
     }
 }

--- a/src/FieldHandlers/TextFieldHandler.php
+++ b/src/FieldHandlers/TextFieldHandler.php
@@ -1,0 +1,28 @@
+<?php
+namespace CsvMigrations\FieldHandlers;
+
+use App\View\AppView;
+use CsvMigrations\FieldHandlers\BaseFieldHandler;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class TextFieldHandler extends BaseFieldHandler
+{
+    /**
+     * Method responsible for converting csv field instance to database field instance.
+     *
+     * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
+     * @return \CsvMigrations\FieldHandlers\DbField            DbField instance
+     */
+    public function fieldToDb(CsvField $csvField)
+    {
+        $dbField = new DbField(
+            $csvField->getName(),
+            $csvField->getType(),
+            MysqlAdapter::TEXT_LONG,
+            $csvField->getRequired(),
+            $csvField->getNonSearchable()
+        );
+
+        return $dbField;
+    }
+}

--- a/src/FieldHandlers/UuidFieldHandler.php
+++ b/src/FieldHandlers/UuidFieldHandler.php
@@ -1,0 +1,8 @@
+<?php
+namespace CsvMigrations\FieldHandlers;
+
+use CsvMigrations\FieldHandlers\BaseFieldHandler;
+
+class UuidFieldHandler extends BaseFieldHandler
+{
+}

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -44,7 +44,9 @@ trait MigrationTrait
         $csvData = [];
         foreach ($csvFiles as $module => $paths) {
             foreach ($paths as $path) {
-                $csvData[$module] = $this->_getCsvData($path);
+                $csvData[$module] = $this->_prepareCsvData(
+                    $this->_getCsvData($path)
+                );
             }
         }
 

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -25,7 +25,6 @@ trait MigrationTrait
     protected $_defaultParams = [
         'name' => '',
         'type' => '',
-        'limit' => '',
         'required' => '',
         'non-searchable' => ''
     ];

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -5,17 +5,18 @@ use Cake\Core\Configure;
 use Cake\Utility\Inflector;
 use CsvMigrations\CsvMigrationsUtils;
 use CsvMigrations\CsvTrait;
+use CsvMigrations\FieldHandlers\CsvField;
 
 trait MigrationTrait
 {
     use CsvTrait;
 
     /**
-     * Pattern for associated fields
+     * Associated fields identifier
      *
      * @var string
      */
-    protected $_patternAssoc = 'related:';
+    protected $_assocIdentifier = 'related';
 
     /**
      * Field parameters
@@ -141,13 +142,14 @@ trait MigrationTrait
 
         foreach ($csvData as $module => $fields) {
             foreach ($fields as $row) {
-                $assocModule = $this->_getAssociatedModuleName($row['type']);
+                $csvField = new CsvField($row);
                 /*
                 Skip if not associated module name was found
                  */
-                if ('' === trim($assocModule)) {
+                if ($this->_assocIdentifier !== $csvField->getType()) {
                     continue;
                 }
+                $assocModule = $csvField->getLimit();
 
                 /*
                 If current model alias matches csv module, then assume belongsTo association.
@@ -192,23 +194,6 @@ trait MigrationTrait
                     }
                 }
             }
-        }
-
-        return $result;
-    }
-
-    /**
-     * Method that extracts module name from field type definition.
-     *
-     * @param  string $name field type
-     * @return string
-     */
-    protected function _getAssociatedModuleName($name)
-    {
-        $result = '';
-        if (false !== $pos = strpos($name, $this->_patternAssoc)) {
-            $result = str_replace($this->_patternAssoc, '', $name);
-            $result = Inflector::camelize($result);
         }
 
         return $result;

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -12,23 +12,16 @@ trait MigrationTrait
     use CsvTrait;
 
     /**
+     * File extension
+     */
+    private $__extension = 'csv';
+
+    /**
      * Associated fields identifier
      *
      * @var string
      */
-    protected $_assocIdentifier = 'related';
-
-    /**
-     * Field parameters
-     *
-     * @var array
-     */
-    protected $_defaultParams = [
-        'name' => '',
-        'type' => '',
-        'required' => '',
-        'non-searchable' => ''
-    ];
+    private $__assocIdentifier = 'related';
 
     /**
      * Method that retrieves fields from csv file and returns them in associate array format.
@@ -38,49 +31,9 @@ trait MigrationTrait
     public function getFieldsDefinitions()
     {
         $path = Configure::readOrFail('CsvMigrations.migrations.path') . $this->alias() . DS;
+        $path .= Configure::readOrFail('CsvMigrations.migrations.filename') . '.' . $this->__extension;
 
-        $csvFiles = $this->_getCsvFile($path);
-
-        $csvData = [];
-        foreach ($csvFiles as $module => $paths) {
-            foreach ($paths as $path) {
-                $csvData[$module] = $this->_prepareCsvData(
-                    $this->_getCsvData($path)
-                );
-            }
-        }
-
-        $result = [];
-        if (!empty($csvData)) {
-            foreach ($csvData as $module => $fields) {
-                foreach ($fields as $row) {
-                    $field = array_combine(array_keys($this->_defaultParams), $row);
-                    $result[$field['name']] = $field;
-                }
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * Method that retrieves csv file path from specified directory.
-     *
-     * @param  string $path directory to search in
-     * @return array        csv file path
-     */
-    protected function _getCsvFile($path)
-    {
-        $result = [];
-        $fileName = Configure::readOrFail('CsvMigrations.migrations.filename');
-        if (file_exists($path)) {
-            $di = new \DirectoryIterator($path);
-            foreach ($di as $fileInfo) {
-                if ($fileInfo->isFile() && $fileName . '.csv' === $fileInfo->getFilename()) {
-                    $result[$this->alias()][] = $fileInfo->getPathname();
-                }
-            }
-        }
+        $result = $this->_prepareCsvData($this->_getCsvData($path));
 
         return $result;
     }
@@ -146,7 +99,7 @@ trait MigrationTrait
                 /*
                 Skip if not associated module name was found
                  */
-                if ($this->_assocIdentifier !== $csvField->getType()) {
+                if ($this->__assocIdentifier !== $csvField->getType()) {
                     continue;
                 }
                 $assocModule = $csvField->getLimit();

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -5,7 +5,7 @@ use Cake\Core\Configure;
 use Cake\Utility\Inflector;
 use CsvMigrations\CsvMigrationsUtils;
 
-trait CsvMigrationsTableTrait
+trait MigrationTrait
 {
     /**
      * Field parameters

--- a/src/Table.php
+++ b/src/Table.php
@@ -3,6 +3,7 @@ namespace CsvMigrations;
 
 use Cake\ORM\Table as BaseTable;
 use CsvMigrations\ConfigurationTrait;
+use CsvMigrations\MigrationTrait;
 
 /**
  * Accounts Model
@@ -11,7 +12,7 @@ use CsvMigrations\ConfigurationTrait;
 class Table extends BaseTable
 {
     use ConfigurationTrait;
-    use CsvMigrationsTableTrait;
+    use MigrationTrait;
 
     /**
      * Searchable parameter name


### PR DESCRIPTION
### Field Handlers
Moved CSV migration columns handling logic into the Field Handlers.

### Csv Field class
Introduced CsvField class which converts the migration CSV file rows into CSV Field objects.

### Db Field class
Introduced DbField class which converts the CSV Field object to DB Field to be used during the CSV migration.

### Csv File structure
Changed csv files structure (breaks backward compatibility). Dropped field-length column, which now is specified within brackets in the field-type column.

**New structure**
```php
FIELD NAME,FIELD TYPE,REQUIRED,NOT SEARCHABLE
id,uuid
name,string(100),1
description,text
currency,list(currencies)
amount,integer(2)
contact_id,related(CrmRe.Contacts),1
document,file,1
```
**Old structure**
```php
FIELD NAME,FIELD TYPE,FIELD LENGTH,REQUIRED,NOT SEARCHABLE
id,uuid,,,
name,string,100,1,
description,text,,,
currency,list:currencies,,,
amount,integer,2,,
contact_id,related:CrmRe.Contacts,,1,
document,file,,1,
```

### Minor changes
* Re-factored CSV migration Traits.
* CSV migration files are not forced to provide all columns with data, so you can skip adding empty values for optional parameters (such as length, required flag and non-searchable flag):
**New**
```php
description,text
```
**Old**
```php
description,text,,,
```