### PR TITLE
 	Fix multiple level associations (task #2137)

### DIFF
--- a/src/CsvMigrationsUtils.php
+++ b/src/CsvMigrationsUtils.php
@@ -18,6 +18,11 @@ class CsvMigrationsUtils
         if ('' !== $foreignKey) {
             $foreignKey = Inflector::camelize($foreignKey);
         }
+        $pos = strpos($plugin, '/');
+        if ($pos) {
+            $plugin = substr($plugin, $pos + 1);
+        }
+
         return $foreignKey . $plugin . $model;
     }
 }

--- a/src/FieldHandlers/CsvField.php
+++ b/src/FieldHandlers/CsvField.php
@@ -214,6 +214,16 @@ class CsvField
     }
 
     /**
+     * The column limit is used also for the module association.
+     *
+     * @return int
+     */
+    public function getAssocCsvModule()
+    {
+        return $this->_limit;
+    }
+
+    /**
      * Field required flag setter.
      *
      * @param string $required field required flag

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -5,6 +5,7 @@ use Cake\Core\Configure;
 use CsvMigrations\CsvMigrationsUtils;
 use CsvMigrations\CsvTrait;
 use CsvMigrations\FieldHandlers\CsvField;
+use RuntimeException;
 
 trait MigrationTrait
 {
@@ -85,33 +86,20 @@ trait MigrationTrait
                 $assoccsvModule = $csvObjField->getAssocCsvModule();
                 $fieldName = $csvObjField->getName();
 
-                //Belongs to association of the curren running module.
-                if ($config['currentMod'] === $csvModule) {
+                if ($config['table'] === $csvModule) {
                     $assocName = CsvMigrationsUtils::createAssociationName($assoccsvModule, $fieldName);
+                    //Belongs to association of the curren running module.
                     $this->belongsTo($assocName, [
                         'className' => $assoccsvModule,
                         'foreignKey' => $fieldName
                     ]);
-                } else {
-                    list(, $mod) = pluginSplit($assoccsvModule);
+                } elseif ($config['table'] === $assoccsvModule) {
                     //Foreignkey found in other module
-                    //Let's create hasMany association.
-                    if ($config['currentMod'] === $mod) {
-                        list($plugin, $controller) = pluginSplit($config['registryAlias']);
-                        /**
-                         * appending plugin name from current table to associated csvModule.
-                         * @todo investigate more, it might break in some cases, such as Files plugin association.
-                         */
-                        if (!is_null($plugin)) {
-                            $assoccsvModule = $plugin . '.' . $csvModule;
-                        }
-                        $assocName = CsvMigrationsUtils::createAssociationName($assoccsvModule, $fieldName);
-                        $this->hasMany($assocName, [
-                            'className' => $assoccsvModule,
-                            'foreignKey' => $fieldName
-                        ]);
-                    }
-
+                    $assocName = CsvMigrationsUtils::createAssociationName($csvModule, $fieldName);
+                    $this->hasMany($assocName, [
+                        'className' => $csvModule,
+                        'foreignKey' => $fieldName
+                    ]);
                 }
 
 

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -139,7 +139,7 @@ trait MigrationTrait
     }
 
     /**
-     * Convert array to object function.
+     * Convert field details into CSV object.
      *
      * @see  _csvData();
      * @param  array  $data The return of _csvData function

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -83,13 +83,14 @@ trait MigrationTrait
         foreach ($csvFilteredData as $csvModule => $fields) {
             foreach ($fields as $csvObjField) {
                 $assoccsvModule = $csvObjField->getAssocCsvModule();
+                $fieldName = $csvObjField->getName();
 
                 //Belongs to association of the curren running module.
                 if ($config['currentMod'] === $csvModule) {
-                    $assocName = CsvMigrationsUtils::createAssociationName($assoccsvModule, $csvObjField->getName());
+                    $assocName = CsvMigrationsUtils::createAssociationName($assoccsvModule, $fieldName);
                     $this->belongsTo($assocName, [
                         'className' => $assoccsvModule,
-                        'foreignKey' => $csvObjField->getName()
+                        'foreignKey' => $fieldName
                     ]);
                 } else {
                     list(, $mod) = pluginSplit($assoccsvModule);
@@ -104,10 +105,10 @@ trait MigrationTrait
                         if (!is_null($plugin)) {
                             $assoccsvModule = $plugin . '.' . $csvModule;
                         }
-                        $assocName = CsvMigrationsUtils::createAssociationName($assoccsvModule, $csvObjField->getName());
+                        $assocName = CsvMigrationsUtils::createAssociationName($assoccsvModule, $fieldName);
                         $this->hasMany($assocName, [
                             'className' => $assoccsvModule,
-                            'foreignKey' => $csvObjField->getName()
+                            'foreignKey' => $fieldName
                         ]);
                     }
 

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -77,17 +77,8 @@ trait MigrationTrait
      */
     protected function _setAssociationsFromCsv(array $config)
     {
-        $path = Configure::readOrFail('CsvMigrations.migrations.path');
-        $csvFiles = $this->_getCsvFiles($path);
-
-        $csvData = [];
-        foreach ($csvFiles as $module => $paths) {
-            foreach ($paths as $path) {
-                $csvData[$module] = $this->_prepareCsvData(
-                    $this->_getCsvData($path)
-                );
-            }
-        }
+        $csvData = $this->_csvData();
+        $curModule = Inflector::camelize($this->table());
 
         if (empty($csvData)) {
             return;
@@ -131,6 +122,26 @@ trait MigrationTrait
                 }
             }
         }
+    }
+
+    /**
+     * [_csvData description]
+     * @param  [type] $path [description]
+     * @return [type]       [description]
+     */
+    protected function _csvData()
+    {
+        $result = [];
+        $path = Configure::readOrFail('CsvMigrations.migrations.path');
+        $csvFiles = $this->_getCsvFiles($path);
+
+        foreach ($csvFiles as $csvModule => $paths) {
+            foreach ($paths as $path) {
+                $result[$csvModule] = $this->_prepareCsvData($this->_getCsvData($path));
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Table.php
+++ b/src/Table.php
@@ -2,6 +2,7 @@
 namespace CsvMigrations;
 
 use Cake\ORM\Table as BaseTable;
+use Cake\Utility\Inflector;
 use CsvMigrations\ConfigurationTrait;
 use CsvMigrations\FieldTrait;
 use CsvMigrations\MigrationTrait;
@@ -56,6 +57,9 @@ class Table extends BaseTable
         if (isset($this->_config['table']['searchable'])) {
             $this->isSearchable($this->_config['table']['searchable']);
         }
+
+        //Set the current module
+        $config['currentMod'] = Inflector::camelize($this->table());
 
         $this->_setAssociations($config);
     }

--- a/src/Table.php
+++ b/src/Table.php
@@ -102,7 +102,7 @@ class Table extends BaseTable
      * Return current table in camelCase form.
      * It adds plugin name as a prefix.
      *
-     * @return string Table Name
+     * @return string Table Name along with its prefix if found.
      */
     protected function _currentTable()
     {

--- a/src/Table.php
+++ b/src/Table.php
@@ -57,10 +57,6 @@ class Table extends BaseTable
             $this->isSearchable($this->_config['table']['searchable']);
         }
 
-        $this->hasMany('UploadDocuments', [
-            'className' => 'Burzum/FileStorage.FileStorage',
-            'foreignKey' => 'foreign_key',
-        ]);
         $this->_setAssociations($config);
     }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -59,8 +59,7 @@ class Table extends BaseTable
         }
 
         //Set the current module
-        $config['currentMod'] = Inflector::camelize($this->table());
-
+        $config['table'] = $this->_currentTable();
         $this->_setAssociations($config);
     }
 
@@ -97,5 +96,23 @@ class Table extends BaseTable
         }
 
         return $result;
+    }
+
+    /**
+     * Return current table in camelCase form.
+     * It adds plugin name as a prefix.
+     *
+     * @return string Table Name
+     */
+    protected function _currentTable()
+    {
+        list($namespace, $alias) = namespaceSplit(get_class($this));
+        $alias = substr($alias, 0, -5);
+        list($plugin) = explode('\\', $namespace);
+        if ($plugin === 'App') {
+            return Inflector::camelize($alias);
+        }
+
+        return Inflector::camelize($plugin . '.' . $alias);
     }
 }


### PR DESCRIPTION
The problem with `$table->alias` is that it takes association name when we deal with associated tables.

As a result, we wouldn't be able to see association when doing the following:

`$this->Projects->Documents->associations();`

So, we replaced it with table which is set in the Table's config as well.