### PR TITLE
Add record id to associated Entity fields, when a lookup field value is used (task #2366)

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -71,6 +71,26 @@ trait ConfigurationTrait
         if (file_exists($path)) {
             $this->_config = parse_ini_file($path, true);
         }
+
+        // display field from configuration file
+        if (isset($this->_config['table']['display_field']) && method_exists($this, 'displayField')) {
+            $this->displayField($this->_config['table']['display_field']);
+        }
+
+        // lookup field(s) from configuration file
+        if (isset($this->_config['table']['lookup_fields'])) {
+            $this->lookupFields($this->_config['table']['lookup_fields']);
+        }
+
+        // set module alias from configuration file
+        if (isset($this->_config['table']['alias'])) {
+            $this->moduleAlias($this->_config['table']['alias']);
+        }
+
+        // set searchable flag from configuration file
+        if (isset($this->_config['table']['searchable'])) {
+            $this->isSearchable($this->_config['table']['searchable']);
+        }
     }
 
     /**

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -5,6 +5,7 @@ use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\Event\Event;
+use Cake\ORM\TableRegistry;
 use Crud\Controller\ControllerTrait;
 use CsvMigrations\CsvTrait;
 use CsvMigrations\FieldHandlers\RelatedFieldTrait;
@@ -119,6 +120,22 @@ class AppController extends Controller
     }
 
     /**
+     * Add CRUD action events handling logic.
+     *
+     * @return \Cake\Network\Response
+     */
+    public function add()
+    {
+        $this->Crud->on('beforeSave', function (Event $event) {
+            // get Entity's Table instance
+            $table = TableRegistry::get($event->subject()->entity->source());
+            $table->setAssociatedByLookupFields($event->subject()->entity);
+        });
+
+        return $this->Crud->execute();
+    }
+
+    /**
      * Edit CRUD action events handling logic.
      *
      * @return \Cake\Network\Response
@@ -131,6 +148,10 @@ class AppController extends Controller
 
         $this->Crud->on('afterFind', function (Event $event) {
             $event = $this->_prettifyEntity($event);
+        });
+
+        $this->Crud->on('beforeSave', function (Event $event) {
+            $event->subject()->repository->setAssociatedByLookupFields($event->subject()->entity);
         });
 
         return $this->Crud->execute();

--- a/src/Table.php
+++ b/src/Table.php
@@ -40,38 +40,8 @@ class Table extends BaseTable
     {
         parent::initialize($config);
 
-        /*
-        set table/module configuration
-         */
+        // set table/module configuration
         $this->_setConfiguration($this->table());
-
-        /*
-        display field from configuration file
-         */
-        if (isset($this->_config['table']['display_field'])) {
-            $this->displayField($this->_config['table']['display_field']);
-        }
-
-        /*
-        lookup field(s) from configuration file
-         */
-        if (isset($this->_config['table']['lookup_fields'])) {
-            $this->lookupFields($this->_config['table']['lookup_fields']);
-        }
-
-        /*
-        set module alias from configuration file
-         */
-        if (isset($this->_config['table']['alias'])) {
-            $this->moduleAlias($this->_config['table']['alias']);
-        }
-
-        /*
-        set searchable flag from configuration file
-         */
-        if (isset($this->_config['table']['searchable'])) {
-            $this->isSearchable($this->_config['table']['searchable']);
-        }
 
         //Set the current module
         $config['table'] = $this->_currentTable();

--- a/src/Table.php
+++ b/src/Table.php
@@ -1,6 +1,7 @@
 <?php
 namespace CsvMigrations;
 
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table as BaseTable;
 use Cake\Utility\Inflector;
@@ -133,6 +134,79 @@ class Table extends BaseTable
         }
 
         return $query;
+    }
+
+    /**
+     * Method that checks Entity's association fields (foreign keys) values and query's the database to find
+     * the associated record. If the record is not found, it query's the database again to find it by its
+     * display field. If found it replaces the associated field's value with the records id.
+     *
+     * This is useful for cases where the display field value is used on the associated field. For example
+     * a new post is created and in the 'owner' field the username of the user is used instead of its uuid.
+     *
+     * BEFORE:
+     * {
+     *    'title' => 'Lorem Ipsum',
+     *    'content' => '.....',
+     *    'owner' => 'admin',
+     * }
+     *
+     * AFTER:
+     * {
+     *    'title' => 'Lorem Ipsum',
+     *    'content' => '.....',
+     *    'owner' => '77dd9203-3f21-4571-8843-0264ae1cfa48',
+     * }
+     *
+     * @param  \Cake\ORM\Entity $entity Entity instance
+     * @return \Cake\ORM\Entity
+     */
+    public function setAssociatedByLookupFields(Entity $entity)
+    {
+        foreach ($this->associations() as $association) {
+            $lookupFields = $association->target()->lookupFields();
+
+            if (empty($lookupFields)) {
+                continue;
+            }
+
+            $value = $entity->{$association->foreignKey()};
+            // skip if association's foreign key is NOT set in the entity
+            if (is_null($value)) {
+                continue;
+            }
+
+            // check if record can be fetched by primary key
+            $found = (bool)$association->target()->find('all', [
+                'conditions' => [$association->primaryKey() => $value]
+            ])->count();
+
+            // skip if record found by primary key
+            if ($found) {
+                continue;
+            }
+
+            // check if record can be fetched by display field
+            $query = $association->target()->find()
+                // select associated record's primary key (usually id)
+                ->select($association->primaryKey());
+
+            // check for record by table's lookup fields
+            foreach ($lookupFields as $lookupField) {
+                $query->orWhere([$lookupField => $value]);
+            }
+
+            $associatedEntity = $query->first();
+
+            // skip if record cannot be found by display field
+            if (is_null($associatedEntity)) {
+                continue;
+            }
+
+            $entity->{$association->foreignKey()} = $associatedEntity->{$association->primaryKey()};
+        }
+
+        return $entity;
     }
 
     /**


### PR DESCRIPTION
Useful for cases where the display field value is used on the associated field. For example a new post is created and in the 'owner' field the username of the user is used instead of its uuid.
```php
BEFORE:
{
    'title' => 'Lorem Ipsum',
    'content' => '.....',
    'owner' => 'admin',
}
```
```php
AFTER:
{
    'title' => 'Lorem Ipsum',
    'content' => '.....',
    'owner' => '77dd9203-3f21-4571-8843-0264ae1cfa48',
}
```