### PR TITLE
Support for configurable typeahead fields (task #2429)

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -42,6 +42,13 @@ trait ConfigurationTrait
     protected $_lookupFields;
 
     /**
+     * Typeahead fields used for searching in related fields
+     *
+     * @var array
+     */
+    protected $_typeaheadFields;
+
+    /**
      * Module alias
      *
      * @var string
@@ -80,6 +87,11 @@ trait ConfigurationTrait
         // lookup field(s) from configuration file
         if (isset($this->_config['table']['lookup_fields'])) {
             $this->lookupFields($this->_config['table']['lookup_fields']);
+        }
+
+        // typeahead field(s) from configuration file
+        if (isset($this->_config['table']['typeahead_fields'])) {
+            $this->typeaheadFields($this->_config['table']['typeahead_fields']);
         }
 
         // set module alias from configuration file
@@ -121,6 +133,21 @@ trait ConfigurationTrait
         }
 
         return $this->_lookupFields;
+    }
+
+    /**
+     * Returns the typeahead fields or sets a new one
+     *
+     * @param string|null $fields sets typeahead fields
+     * @return string
+     */
+    public function typeaheadFields($fields = null)
+    {
+        if ($fields !== null) {
+            $this->_typeaheadFields = explode(',', $fields);
+        }
+
+        return $this->_typeaheadFields;
     }
 
     /**

--- a/webroot/js/typeahead.js
+++ b/webroot/js/typeahead.js
@@ -89,7 +89,11 @@ var typeahead = typeahead || {};
             },
             onSelect: function(data) {
                 that._onSelect(input, hidden_input, data);
-            }
+            },
+            // No need to run matcher as ajax results are already filtered
+            matcher: function (item) {
+                return true;
+            },
         });
     };
 


### PR DESCRIPTION
Added support for configurable typeahead fields.  The module`config.ini` can have something like this:

```
[table]
display_field = name
typeahead_fields = first_name,last_name,company_name,email
```

One side benefit to this change is that a virtual field can be used for `display_field`.  Previously, virtual fields would break the typeahead, as CakePHP does not allow for virtual fields to be used in database queries.  It is for that reason that typeahead list of fields should also NOT contain any virtual fields.