### PR TITLE
Fixed error 500 on virtual display field (task #2430)

### DIFF
--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -208,15 +208,20 @@ class CsvViewComponent extends Component
         }
 
         $connection = ConnectionManager::get('default');
+        // NOTE: This will break if $assocTableName has no primary key or has a combined primary key
         $records = $connection
             ->execute(
-                'SELECT ' . $assocTableName . '.' . $displayField . ' FROM ' . $tableName . ' LEFT JOIN ' . $assocTableName . ' ON ' . $tableName . '.' . $assocForeignKey . ' = ' . $assocTableName . '.' . $assocPrimaryKey . ' WHERE ' . $tableName . '.' . $primaryKey . ' = :id LIMIT 1',
+                'SELECT ' . $assocTableName . '.' . $assocPrimaryKey . ' FROM ' . $tableName . ' LEFT JOIN ' . $assocTableName . ' ON ' . $tableName . '.' . $assocForeignKey . ' = ' . $assocTableName . '.' . $assocPrimaryKey . ' WHERE ' . $tableName . '.' . $primaryKey . ' = :id LIMIT 1',
                 ['id' => $recordId]
             )
             ->fetchAll('assoc');
 
         // store associated table records
-        $result = $records[0][$displayField];
+        if (!empty($records[0][$assocPrimaryKey])) {
+            $result = $association->get($records[0][$assocPrimaryKey])->$displayField;
+        } else {
+            $result = null;
+        }
 
         return $result;
     }


### PR DESCRIPTION
Display field was used in the SELECT query, which broke if display
field was a virtual field.  A workaround has been applied, with the
following side effects:

* Additional SQL queries are needed to fetch the record for which a
  display field is needed.
* Primary key is used instead of display field for locating the record,
  but with the current query things will break if the primary key is
  either not defined, or is a composite key (multiple fields).