### PR TITLE
Fixing PHP Notices from CsvField (task #2431)

### DIFF
--- a/src/FieldHandlers/CsvField.php
+++ b/src/FieldHandlers/CsvField.php
@@ -43,6 +43,26 @@ class CsvField
     const FIELD_UNIQUE = 'unique';
 
     /**
+     * Default value for field type
+     */
+    const DEFAULT_FIELD_TYPE = 'string';
+
+    /**
+     * Default value for field required
+     */
+    const DEFAULT_FIELD_REQUIRED = false;
+
+    /**
+     * Default value for field non-searchable
+     */
+    const DEFAULT_FIELD_NON_SEARCHABLE = false;
+
+    /**
+     * Default value for field unique
+     */
+    const DEFAULT_FIELD_UNIQUE = false;
+
+    /**
      * field name
      *
      * @var string
@@ -91,12 +111,33 @@ class CsvField
      */
     public function __construct(array $row)
     {
+        // Merge row values with defaults
+        $defaults = $this->_getDefaults();
+        $row = array_merge($defaults, $row);
+
         $this->setName($row[static::FIELD_NAME]);
         $this->setType($row[static::FIELD_TYPE]);
         $this->setLimit($row[static::FIELD_TYPE]);
         $this->setRequired($row[static::FIELD_REQUIRED]);
         $this->setNonSearchable($row[static::FIELD_NON_SEARCHABLE]);
         $this->setUnique($row[static::FIELD_UNIQUE]);
+    }
+
+    /**
+     * Get default values
+     *
+     * @return array
+     */
+    protected function _getDefaults()
+    {
+        $result = [
+            static::FIELD_TYPE => static::DEFAULT_FIELD_TYPE,
+            static::FIELD_REQUIRED => static::DEFAULT_FIELD_REQUIRED,
+            static::FIELD_NON_SEARCHABLE => static::DEFAULT_FIELD_NON_SEARCHABLE,
+            static::FIELD_UNIQUE => static::DEFAULT_FIELD_UNIQUE,
+        ];
+
+        return $result;
     }
 
     /**

--- a/src/FieldHandlers/CsvField.php
+++ b/src/FieldHandlers/CsvField.php
@@ -48,6 +48,11 @@ class CsvField
     const DEFAULT_FIELD_TYPE = 'string';
 
     /**
+     * Default value for field limit
+     */
+    const DEFAULT_FIELD_LIMIT = null;
+
+    /**
      * Default value for field required
      */
     const DEFAULT_FIELD_REQUIRED = false;
@@ -168,7 +173,7 @@ class CsvField
             preg_match(static::PATTERN_TYPE, $type, $matches);
             $limit = $matches[2];
         } else {
-            $limit = null;
+            $limit = static::DEFAULT_FIELD_LIMIT;
         }
 
         return $limit;

--- a/tests/TestCase/FieldHandlers/CsvFieldTest.php
+++ b/tests/TestCase/FieldHandlers/CsvFieldTest.php
@@ -21,6 +21,33 @@ class CsvFieldTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that default values are set correct
+     *
+     * @see Task #2431
+     */
+    public function testDefaults()
+    {
+        $csvField = new CsvField(['name' => 'foobar']);
+
+        $this->assertEquals('foobar', $csvField->getName(), "Field name was not set correctly");
+
+        $this->assertEquals('string', $csvField->getType(), "Default field type was not set to string");
+        $this->assertEquals(CsvField::DEFAULT_FIELD_TYPE, $csvField->getType(), "Default field type was not set to correctly");
+
+        $this->assertEquals(null, $csvField->getLimit(), "Field limit was not set to null");
+        $this->assertEquals(CsvField::DEFAULT_FIELD_LIMIT, $csvField->getLimit(), "Default field limit was not set coorectly");
+
+        $this->assertEquals(false, $csvField->getRequired(), "Field required was not set to false");
+        $this->assertEquals(CsvField::DEFAULT_FIELD_REQUIRED, $csvField->getRequired(), "Default field required was not set coorectly");
+
+        $this->assertEquals(false, $csvField->getNonSearchable(), "Field non-searchable was not set to false");
+        $this->assertEquals(CsvField::DEFAULT_FIELD_NON_SEARCHABLE, $csvField->getNonSearchable(), "Default field non-searchable was not set coorectly");
+
+        $this->assertEquals(false, $csvField->getUnique(), "Field unique was not set to false");
+        $this->assertEquals(CsvField::DEFAULT_FIELD_UNIQUE, $csvField->getUnique(), "Default field unique was not set coorectly");
+    }
+
+    /**
      * @dataProvider nameSetterProvider
      */
     public function testSetName($expected, $name)


### PR DESCRIPTION
CsvField class assumed that given row contained all
values and columns.  One particular scenario where
this is not true, is when a virtual field is passed
around.

Fixing the issue with some common sense defaults.