### PR TITLE
Format migration timestamp

### DIFF
--- a/src/Shell/Task/CsvMigrationTask.php
+++ b/src/Shell/Task/CsvMigrationTask.php
@@ -115,6 +115,9 @@ class CsvMigrationTask extends MigrationTask
             throw new MissingCsvException($tableName);
         }
 
-        return filemtime($path);
+        // Unit time stamp to YYYYMMDDhhmmss
+        $result = date('YmdHis', filemtime($path));
+
+        return $result;
     }
 }


### PR DESCRIPTION
When creating migration files from the shell,
we need to make sure that the resulting class
and file name are unique.  Migration timestamp
is already included via CakePHP/Phinx, so that
option is out.

We've tried a variety of random bits as a unique
suffix, but none of them look good.  So, taking
the last modified timestamp from the CSV file of
which the migration is based, seems like the best
option.

This means that now there will be two timestamps
in the name of the file:

1. Timestamp of when the migration class was created.
2. Timestamp of when the migration CSV was last modified.

And there will be one timestamp in the name of the class:

1. Timestamp of when the migration CSV was last modified.

This provides additional assistance when matching migration
classes to their respective CSV files in version control
history.  (There might be a significant delay between the
last update to the CSV and when the migration class is
generated off it.)