### PR TITLE
Fix 'Permission denied' error (task #2477)

### DIFF
--- a/src/Parser/Csv/Parser.php
+++ b/src/Parser/Csv/Parser.php
@@ -18,6 +18,11 @@ use League\Csv\Reader;
 class Parser implements ParserInterface
 {
     /**
+     * Mode to use for opening CSV files
+     */
+    protected $open_mode = 'r';
+
+    /**
      * File structure
      */
     protected $structure = [];
@@ -47,7 +52,7 @@ class Parser implements ParserInterface
             $this->structure = $this->getHeadersFromPath($path);
         }
 
-        $reader = Reader::createFromPath($path);
+        $reader = Reader::createFromPath($path, $this->open_mode);
         $rows = $reader->setOffset(1)->fetchAssoc($this->structure);
         foreach ($rows as $row) {
             $result[] = $row;
@@ -68,7 +73,7 @@ class Parser implements ParserInterface
 
         $this->validatePath($path);
 
-        $reader = Reader::createFromPath($path);
+        $reader = Reader::createFromPath($path, $this->open_mode);
         $result = $reader->fetchOne();
 
         return $result;

--- a/src/Parser/Csv/ViewParser.php
+++ b/src/Parser/Csv/ViewParser.php
@@ -23,6 +23,11 @@ use League\Csv\Reader;
 class ViewParser implements ParserInterface
 {
     /**
+     * Mode to use for opening CSV files
+     */
+    protected $open_mode = 'r';
+
+    /**
      * Parse from path
      *
      * Parses a given file and return a list of all
@@ -52,7 +57,7 @@ class ViewParser implements ParserInterface
             $this->structure = $this->getHeadersFromPath($path);
         }
 
-        $reader = Reader::createFromPath($path);
+        $reader = Reader::createFromPath($path, $this->open_mode);
         $result = $reader->setOffset(1)->fetchAll();
 
         return $result;
@@ -70,7 +75,7 @@ class ViewParser implements ParserInterface
 
         $this->validatePath($path);
 
-        $reader = Reader::createFromPath($path);
+        $reader = Reader::createFromPath($path, $this->open_mode);
         $result = $reader->fetchOne();
 
         return $result;


### PR DESCRIPTION
When opening the files for parsing only, the 'r' mode should be
used, as files might be in places, where web server cannot write.

`league/csv` library opens them by default with mode 'r+', which
makes sense for it, as it can both read and write CSV files and
not necessarily in the web context.