### PR TITLE
Refactor field handler to rely only to autoloader (task #2493)

### DIFF
--- a/src/FieldHandlers/CsvField.php
+++ b/src/FieldHandlers/CsvField.php
@@ -218,7 +218,8 @@ class CsvField
 
         $type = $this->_extractType($type);
 
-        if (!in_array($type, FieldHandlerFactory::getList())) {
+        $fhf = new FieldHandlerFactory();
+        if (!$fhf->hasFieldHandler($type)) {
             throw new InvalidArgumentException(__CLASS__ . ': Unsupported field type: ' . $type);
         }
 

--- a/tests/TestCase/FieldHandlers/FieldHandlerFactoryTest.php
+++ b/tests/TestCase/FieldHandlers/FieldHandlerFactoryTest.php
@@ -94,6 +94,15 @@ class FieldHandlerFactoryTest extends TestCase
         $this->fhf = new FieldHandlerFactory();
     }
 
+    public function testHasFieldHandler()
+    {
+        $result = $this->fhf->hasFieldHandler('string');
+        $this->assertTrue($result, "Failed to find field handler for type 'string'");
+
+        $result = $this->fhf->hasFieldHandler('non-existing-field-type');
+        $this->assertFalse($result, "Found field handler for type 'non-existing-field-type'");
+    }
+
     public function testRenderInput()
     {
         $foos = $this->FooTable->find();


### PR DESCRIPTION
Field handler factory should rely only on autoloader, and not
traverse through class directories, trying to find files.  If it
does, then field handlers cannot be extended via external libraries.

This commit removes the directory search and replaces a `getList()`
implementation with `hasFieldHandler()` check.