### PR TITLE
Fixed combined field input label

### DIFF
--- a/src/FieldHandlers/BaseCombinedFieldHandler.php
+++ b/src/FieldHandlers/BaseCombinedFieldHandler.php
@@ -36,7 +36,7 @@ abstract class BaseCombinedFieldHandler extends ListFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
-        $input = $this->cakeView->Form->label($field . ' ' . key($this->_fields));
+        $input = $this->cakeView->Form->label($field);
 
         $input .= '<div class="row">';
         foreach ($this->_fields as $suffix => $preOptions) {


### PR DESCRIPTION
This commit removes the extra text from the input field label for
combined fields.  Until now we were using field + the name of the
first field in the list of combined fields, resulting in things
like: "Amound Paid Amount" instead of "Amount Paid".