### PR TITLE
Switch views pagination to datatables (task #2629)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -12,6 +12,8 @@ Configure::write('CsvMigrations.migrations.filename', 'migration');
 Configure::write('CsvMigrations.typeahead.min_length', 1);
 Configure::write('CsvMigrations.typeahead.timeout', 300);
 Configure::write('CsvMigrations.api', [
+    'auth' => true,
+    'token' => null,
     'menus_property' => '_Menus',
     'excluded_menus' => [
         'index' => ['top']

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -23,25 +23,6 @@ Configure::write('CsvMigrations.api', [
         'index' => ['top']
     ]
 ]);
-Configure::write('CsvMigrations.menus', [
-    'index' => ['top', 'actions'],
-    'view' => ['top', 'top-row', 'associated']
-]);
-Configure::write('CsvMigrations.events', [
-    'index' => [
-        'menus' => [
-            'top' => ['View.Index.Menu.Top' => 'getIndexMenuTop'],
-            'actions' => ['View.Index.Menu.Actions' => 'getIndexMenuActions']
-        ]
-    ],
-    'view' => [
-        'menus' => [
-            'top' => ['View.View.Menu.Top' => 'getViewMenuTop'],
-            'top-row' => ['View.View.Menu.Top.Row' => 'getViewMenuTopRow'],
-            'associated' => ['View.Associated.Menu.Actions' => 'getAssociatedMenuActions']
-        ]
-    ]
-]);
 
 EventManager::instance()->on(new ViewMenuListener());
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -11,6 +11,10 @@ Configure::write('CsvMigrations.lists.path', CONFIG . 'CsvMigrations' . DS . 'li
 Configure::write('CsvMigrations.migrations.filename', 'migration');
 Configure::write('CsvMigrations.typeahead.min_length', 1);
 Configure::write('CsvMigrations.typeahead.timeout', 300);
+Configure::write('CsvMigrations.acl', [
+    'class' => null, // currently only accepts Table class with prefixed plugin name. Example: 'MyPlugin.TableName'
+    'method' => null
+]);
 Configure::write('CsvMigrations.api', [
     'auth' => true,
     'token' => null,

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -3,7 +3,11 @@ use Burzum\FileStorage\Storage\Listener\BaseListener;
 use Burzum\FileStorage\Storage\StorageManager;
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
+use CsvMigrations\Events\AddViewListener;
+use CsvMigrations\Events\EditViewListener;
+use CsvMigrations\Events\IndexViewListener;
 use CsvMigrations\Events\ViewMenuListener;
+use CsvMigrations\Events\ViewViewListener;
 
 Configure::write('CsvMigrations.migrations.path', CONFIG . 'CsvMigrations' . DS . 'migrations' . DS);
 Configure::write('CsvMigrations.views.path', CONFIG . 'CsvMigrations' . DS . 'views' . DS);
@@ -17,14 +21,14 @@ Configure::write('CsvMigrations.acl', [
 ]);
 Configure::write('CsvMigrations.api', [
     'auth' => true,
-    'token' => null,
-    'menus_property' => '_Menus',
-    'excluded_menus' => [
-        'index' => ['top']
-    ]
+    'token' => null
 ]);
 
+EventManager::instance()->on(new AddViewListener());
+EventManager::instance()->on(new EditViewListener());
+EventManager::instance()->on(new IndexViewListener());
 EventManager::instance()->on(new ViewMenuListener());
+EventManager::instance()->on(new ViewViewListener());
 
 //Load upload plugin configuration
 include 'file_storage.php';

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -11,6 +11,31 @@ Configure::write('CsvMigrations.lists.path', CONFIG . 'CsvMigrations' . DS . 'li
 Configure::write('CsvMigrations.migrations.filename', 'migration');
 Configure::write('CsvMigrations.typeahead.min_length', 1);
 Configure::write('CsvMigrations.typeahead.timeout', 300);
+Configure::write('CsvMigrations.api', [
+    'menus_property' => '_Menus',
+    'excluded_menus' => [
+        'index' => ['top']
+    ]
+]);
+Configure::write('CsvMigrations.menus', [
+    'index' => ['top', 'actions'],
+    'view' => ['top', 'top-row', 'associated']
+]);
+Configure::write('CsvMigrations.events', [
+    'index' => [
+        'menus' => [
+            'top' => ['View.Index.Menu.Top' => 'getIndexMenuTop'],
+            'actions' => ['View.Index.Menu.Actions' => 'getIndexMenuActions']
+        ]
+    ],
+    'view' => [
+        'menus' => [
+            'top' => ['View.View.Menu.Top' => 'getViewMenuTop'],
+            'top-row' => ['View.View.Menu.Top.Row' => 'getViewMenuTopRow'],
+            'associated' => ['View.Associated.Menu.Actions' => 'getAssociatedMenuActions']
+        ]
+    ]
+]);
 
 EventManager::instance()->on(new ViewMenuListener());
 

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -1,7 +1,7 @@
 <?php
 namespace CsvMigrations\Controller\Api;
 
-use Cake\Controller\Controller;
+use App\Controller\AppController as BaseController;
 use Cake\Core\Configure;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\Event\Event;
@@ -16,7 +16,7 @@ use CsvMigrations\Panel;
 use CsvMigrations\PanelUtilTrait;
 use CsvMigrations\PrettifyTrait;
 
-class AppController extends Controller
+class AppController extends BaseController
 {
     /**
      * Pretty format identifier

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -25,16 +25,6 @@ class AppController extends Controller
     const FORMAT_PRETTY = 'pretty';
 
     /**
-     * Events identifier
-     */
-    const EVENTS = 'CsvMigrations.events';
-
-    /**
-     * Menu events identifier
-     */
-    const EVENTS_MENU = 'menus';
-
-    /**
      * Include menus identifier
      */
     const FLAG_INCLUDE_MENUS = 'menus';

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -156,14 +156,11 @@ class AppController extends Controller
      */
     protected function _authentication()
     {
-        if (isset($this->Auth)) {
-            // overwrite Authentication component config, with API authentication
-            foreach ($this->_authConfig as $key => $value) {
-                $this->Auth->config($key, $value, false);
-            }
-        } else {
-            $this->loadComponent('Auth', $this->_authConfig);
-        }
+        $this->loadComponent('Auth', $this->_authConfig);
+
+        // set auth user from token
+        $user = $this->Auth->getAuthenticate('ADmad/JwtAuth.Jwt')->getUser($this->request);
+        $this->Auth->setUser($user);
 
         // If API authentication is disabled, allow access to all actions. This is useful when using some
         // other kind of access control check.

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -1,7 +1,7 @@
 <?php
 namespace CsvMigrations\Controller\Api;
 
-use App\Controller\AppController as BaseController;
+use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\Event\Event;
@@ -16,7 +16,7 @@ use CsvMigrations\Panel;
 use CsvMigrations\PanelUtilTrait;
 use CsvMigrations\PrettifyTrait;
 
-class AppController extends BaseController
+class AppController extends Controller
 {
     /**
      * Pretty format identifier

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -135,6 +135,8 @@ class AppController extends BaseController
 
         $this->_fileUploadsUtils = new FileUploadsUtils($this->{$this->name});
 
+        $this->loadComponent('Csrf');
+
         $this->_authentication();
     }
 

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -43,6 +43,11 @@ class AppController extends Controller
      */
     const MENU_PROPERTY_NAME = '_Menus';
 
+    /**
+     * API authentication action identifier
+     */
+    const AUTH_ACTION = 'token';
+
     use ControllerTrait;
     use MigrationTrait;
     use PanelUtilTrait;
@@ -394,6 +399,12 @@ class AppController extends Controller
     public function beforeFilter(Event $event)
     {
         parent::beforeFilter($event);
+
+        if (static::AUTH_ACTION === $this->request->action) {
+            // disable CSRF Component for API authentication action
+            // @link http://book.cakephp.org/3.0/en/controllers/components/csrf.html#disabling-the-csrf-component-for-specific-actions
+            $this->eventManager()->off($this->Csrf);
+        }
 
         $this->response->cors($this->request)
             ->allowOrigin(['*'])

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -280,7 +280,6 @@ class AppController extends Controller
         });
 
         $this->Crud->on('afterFind', function (Event $event) {
-            $event = $this->_prettifyEntity($event);
         });
 
         $this->Crud->on('beforeSave', function (Event $event) {

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -44,11 +44,6 @@ class AppController extends Controller
      */
     const MENU_PROPERTY_NAME = '_Menus';
 
-    /**
-     * API authentication action identifier
-     */
-    const AUTH_ACTION = 'token';
-
     use ControllerTrait;
     use MigrationTrait;
     use PanelUtilTrait;
@@ -107,6 +102,13 @@ class AppController extends Controller
         'unauthorizedRedirect' => false,
         'checkAuthIn' => 'Controller.initialize'
     ];
+
+    /**
+     * API non-csrf actions
+     *
+     * @var array
+     */
+    protected $_nonCsrfActions = ['token'];
 
     protected $_fileUploadsUtils;
 
@@ -434,7 +436,7 @@ class AppController extends Controller
     {
         parent::beforeFilter($event);
 
-        if (static::AUTH_ACTION === $this->request->action) {
+        if (in_array($this->request->action, $this->_nonCsrfActions)) {
             // disable CSRF Component for API authentication action
             // @link http://book.cakephp.org/3.0/en/controllers/components/csrf.html#disabling-the-csrf-component-for-specific-actions
             $this->eventManager()->off($this->Csrf);

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -52,7 +52,6 @@ class AppController extends BaseController
     public function index()
     {
         $this->render('CsvMigrations.Common/index');
-        $this->set('_serialize', ['entities']);
     }
 
     /**

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -51,7 +51,6 @@ class AppController extends BaseController
      */
     public function index()
     {
-        $this->set('entities', $this->paginate($this->{$this->name}));
         $this->render('CsvMigrations.Common/index');
         $this->set('_serialize', ['entities']);
     }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -14,7 +14,10 @@ class AppController extends BaseController
     public function initialize()
     {
         parent::initialize();
+
         $this->_fileUploadsUtils = new FileUploadsUtils($this->{$this->name});
+
+        $this->loadComponent('CsvMigrations.CsvView');
     }
 
     /**

--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -23,16 +23,6 @@ class CsvViewComponent extends Component
     use PanelUtilTrait;
 
     /**
-     * Menus identifier
-     */
-    const MENUS = 'CsvMigrations.menus';
-
-    /**
-     * Excluded API menus identifier
-     */
-    const MENUS_API_EXCLUDED = 'CsvMigrations.api.excluded_menus';
-
-    /**
      * Associated fields action name.
      */
     const ASSOC_FIELDS_ACTION = 'index';
@@ -107,7 +97,6 @@ class CsvViewComponent extends Component
 
         $path = Configure::readOrFail('CsvMigrations.views.path');
         $this->_setTableFields($path);
-        $this->_setMenus($this->request->action);
     }
 
     /**
@@ -392,20 +381,6 @@ class CsvViewComponent extends Component
         }
         $this->_controllerInstance->set('fields', $result);
         $this->_controllerInstance->set('_serialize', ['fields']);
-    }
-
-    /**
-     * Method that passes, to the View, a list of menu names based on specified action.
-     *
-     * @param  string $action Action name
-     * @return void
-     */
-    protected function _setMenus($action)
-    {
-        $menus = (array)Configure::read(static::MENUS . '.' . $action);
-        $excludedMenus = (array)Configure::read(static::MENUS_API_EXCLUDED . '.' . $action);
-
-        $this->_registry->getController()->set('menus', array_diff($menus, $excludedMenus));
     }
 
     /**

--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -23,6 +23,16 @@ class CsvViewComponent extends Component
     use PanelUtilTrait;
 
     /**
+     * Menus identifier
+     */
+    const MENUS = 'CsvMigrations.menus';
+
+    /**
+     * Excluded API menus identifier
+     */
+    const MENUS_API_EXCLUDED = 'CsvMigrations.api.excluded_menus';
+
+    /**
      * Associated fields action name.
      */
     const ASSOC_FIELDS_ACTION = 'index';
@@ -97,6 +107,7 @@ class CsvViewComponent extends Component
 
         $path = Configure::readOrFail('CsvMigrations.views.path');
         $this->_setTableFields($path);
+        $this->_setMenus($this->request->action);
     }
 
     /**
@@ -384,7 +395,22 @@ class CsvViewComponent extends Component
     }
 
     /**
+     * Method that passes, to the View, a list of menu names based on specified action.
+     *
+     * @param  string $action Action name
+     * @return void
+     */
+    protected function _setMenus($action)
+    {
+        $menus = (array)Configure::read(static::MENUS . '.' . $action);
+        $excludedMenus = (array)Configure::read(static::MENUS_API_EXCLUDED . '.' . $action);
+
+        $this->_registry->getController()->set('menus', array_diff($menus, $excludedMenus));
+    }
+
+    /**
      * Method that gets fields from a csv file
+     *
      * @param  string $path   csv file path
      * @return array          csv data
      */

--- a/src/Events/AddViewListener.php
+++ b/src/Events/AddViewListener.php
@@ -1,0 +1,37 @@
+<?php
+namespace CsvMigrations\Events;
+
+use Cake\Event\Event;
+use Cake\ORM\Entity;
+use CsvMigrations\Events\BaseViewListener;
+
+
+class AddViewListener extends BaseViewListener
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function implementedEvents()
+    {
+        return [
+            'CsvMigrations.Add.beforeSave' => 'beforeSave',
+            'CsvMigrations.Add.afterSave' => 'afterSave'
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeSave(Event $event, Entity $entity)
+    {
+        $this->_associatedByLookupFields($entity, $event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function afterSave(Event $event, Entity $entity)
+    {
+        //
+    }
+}

--- a/src/Events/AddViewListener.php
+++ b/src/Events/AddViewListener.php
@@ -5,7 +5,6 @@ use Cake\Event\Event;
 use Cake\ORM\Entity;
 use CsvMigrations\Events\BaseViewListener;
 
-
 class AddViewListener extends BaseViewListener
 {
     /**

--- a/src/Events/BaseViewListener.php
+++ b/src/Events/BaseViewListener.php
@@ -45,6 +45,14 @@ abstract class BaseViewListener implements EventListenerInterface
         ['Documents', 'Files', 'Burzum/FileStorage.FileStorage']
     ];
 
+    /**
+     * Wrapper method that checks if Table instance has method 'findByLookupFields'
+     * and if it does, it calls it, passing along the required arguments.
+     *
+     * @param  \Cake\ORM\Entity  $entity Entity
+     * @param  \Cake\Event\Event $event  Event instance
+     * @return void
+     */
     protected function _lookupFields(Query $query, Event $event)
     {
         $methodName = 'findByLookupFields';
@@ -57,6 +65,14 @@ abstract class BaseViewListener implements EventListenerInterface
         $table->{$methodName}($query, $id);
     }
 
+    /**
+     * Wrapper method that checks if Table instance has method 'setAssociatedByLookupFields'
+     * and if it does, it calls it, passing along the required arguments.
+     *
+     * @param  \Cake\ORM\Entity  $entity Entity
+     * @param  \Cake\Event\Event $event  Event instance
+     * @return void
+     */
     protected function _associatedByLookupFields(Entity $entity, Event $event)
     {
         $methodName = 'setAssociatedByLookupFields';
@@ -68,6 +84,13 @@ abstract class BaseViewListener implements EventListenerInterface
         $table->{$methodName}($entity);
     }
 
+    /**
+     * Method that fetches action fields from the corresponding csv file.
+     *
+     * @param  \Cake\Network\Request $request Request object
+     * @param  string                $action  Action name
+     * @return array
+     */
     protected function _getActionFields(Request $request, $action = null)
     {
         $result = [];

--- a/src/Events/BaseViewListener.php
+++ b/src/Events/BaseViewListener.php
@@ -5,12 +5,14 @@ use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
+use Cake\Log\Log;
 use Cake\Network\Request;
 use Cake\ORM\AssociationCollection;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use CsvMigrations\Parser\Csv\ViewParser;
 use CsvMigrations\PrettifyTrait;
+use InvalidArgumentException;
 
 abstract class BaseViewListener implements EventListenerInterface
 {
@@ -78,9 +80,11 @@ abstract class BaseViewListener implements EventListenerInterface
 
         $path = Configure::read('CsvMigrations.views.path') . $controller . DS . $action . '.csv';
 
-        if (is_readable($path)) {
+        try {
             $parser = new ViewParser();
             $result = $parser->parseFromPath($path);
+        } catch (InvalidArgumentException $e) {
+            Log::error($e);
         }
 
         return $result;

--- a/src/Events/BaseViewListener.php
+++ b/src/Events/BaseViewListener.php
@@ -49,8 +49,8 @@ abstract class BaseViewListener implements EventListenerInterface
      * Wrapper method that checks if Table instance has method 'findByLookupFields'
      * and if it does, it calls it, passing along the required arguments.
      *
-     * @param  \Cake\ORM\Entity  $entity Entity
-     * @param  \Cake\Event\Event $event  Event instance
+     * @param  \Cake\ORM\Query   $query the Query
+     * @param  \Cake\Event\Event $event Event instance
      * @return void
      */
     protected function _lookupFields(Query $query, Event $event)

--- a/src/Events/BaseViewListener.php
+++ b/src/Events/BaseViewListener.php
@@ -1,0 +1,224 @@
+<?php
+namespace CsvMigrations\Events;
+
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\Network\Request;
+use Cake\ORM\AssociationCollection;
+use Cake\ORM\Entity;
+use Cake\ORM\Query;
+use CsvMigrations\Parser\Csv\ViewParser;
+use CsvMigrations\PrettifyTrait;
+
+abstract class BaseViewListener implements EventListenerInterface
+{
+    use PrettifyTrait;
+
+    /**
+     * Datatables format identifier
+     */
+    const FORMAT_DATATABLES = 'datatables';
+
+    /**
+     * Here we list forced associations when fetching record(s) associated data.
+     * This is useful, for example, when trying to fetch a record(s) associated
+     * documents (such as photos, pdfs etc), which are nested two levels deep.
+     *
+     * To detect these nested associations, since our association names
+     * are constructed dynamically, we use the associations class names
+     * as identifiers.
+     *
+     * @var array
+     */
+    protected $_nestedAssociations = [];
+
+    /**
+     * Nested association chain for retrieving associated file records
+     *
+     * @var array
+     */
+    protected $_fileAssociations = [
+        ['Documents', 'Files', 'Burzum/FileStorage.FileStorage']
+    ];
+
+    protected function _lookupFields(Query $query, Event $event)
+    {
+        $methodName = 'findByLookupFields';
+        $table = $event->subject()->{$event->subject()->name};
+        if (!method_exists($table, $methodName) || !is_callable([$table, $methodName])) {
+            return;
+        }
+        $id = $event->subject()->request['pass'][0];
+
+        $table->{$methodName}($query, $id);
+    }
+
+    protected function _associatedByLookupFields(Entity $entity, Event $event)
+    {
+        $methodName = 'setAssociatedByLookupFields';
+        $table = $event->subject()->{$event->subject()->name};
+        if (!method_exists($table, $methodName) || !is_callable([$table, $methodName])) {
+            return;
+        }
+
+        $table->{$methodName}($entity);
+    }
+
+    protected function _getActionFields(Request $request, $action = null)
+    {
+        $result = [];
+
+        $controller = $request->controller;
+
+        if (is_null($action)) {
+            $action = $request->action;
+        }
+
+        $path = Configure::read('CsvMigrations.views.path') . $controller . DS . $action . '.csv';
+
+        if (is_readable($path)) {
+            $parser = new ViewParser();
+            $result = $parser->parseFromPath($path);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Method responsible for retrieving current Table's associations
+     *
+     * @param  Cake\Event\Event $event Event instance
+     * @return array
+     */
+    protected function _getAssociations(Event $event)
+    {
+        $result = [];
+
+        if (!$event->subject()->request->query('associated')) {
+            return $result;
+        }
+
+        $table = $event->subject()->{$event->subject()->name};
+        $associations = $table->associations();
+
+        if (empty($associations)) {
+            return $result;
+        }
+
+        $result = $this->_containAssociations(
+            $associations,
+            $this->_nestedAssociations
+        );
+
+        // always include file associations
+        $result = array_merge(
+            $result,
+            $this->_containAssociations(
+                $associations,
+                $this->_fileAssociations,
+                true
+            )
+        );
+
+        return $result;
+    }
+
+    /**
+     * Method that retrieve's Table association names
+     * to be passed to the ORM Query.
+     *
+     * Nested associations can travel as many levels deep
+     * as defined in the parameter array. Using the example
+     * array below, our code will look for a direct association
+     * with class name 'Documents'. If found, it will add the
+     * association's name to the result array and it will loop
+     * through its associations to look for a direct association
+     * with class name 'Files'. If found again, it will add it to
+     * the result array (nested within the Documents association name)
+     * and will carry on until it runs out of nesting levels or
+     * matching associations.
+     *
+     * Example array:
+     * ['Documents', 'Files', 'Burzum/FileStorage.FileStorage']
+     *
+     * Example result:
+     * [
+     *     'PhotosDocuments' => [
+     *         'DocumentIdFiles' => [
+     *             'FileIdFileStorageFileStorage' => []
+     *         ]
+     *     ]
+     * ]
+     *
+     * @param  Cake\ORM\AssociationCollection $associations       Table associations
+     * @param  array                          $nestedAssociations Nested associations
+     * @param  bool                           $onlyNested         Flag for including only nested associations
+     * @return array
+     */
+    protected function _containAssociations(
+        AssociationCollection $associations,
+        array $nestedAssociations = [],
+        $onlyNested = false
+    ) {
+        $result = [];
+
+        foreach ($associations as $association) {
+            if (!$onlyNested) {
+                $result[$association->name()] = [];
+            }
+
+            if (empty($nestedAssociations)) {
+                continue;
+            }
+
+            foreach ($nestedAssociations as $levels) {
+                if (current($levels) !== $association->className()) {
+                    continue;
+                }
+
+                if (!next($levels)) {
+                    continue;
+                }
+
+                $result[$association->name()] = $this->_containNestedAssociations(
+                    $association->target()->associations(),
+                    array_slice($levels, key($levels))
+                );
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Method that retrieve's Table association nested associations
+     * names to be passed to the ORM Query.
+     *
+     * @param  Cake\ORM\AssociationCollection $associations Table associations
+     * @param  array                          $levels       Nested associations
+     * @return array
+     */
+    protected function _containNestedAssociations(AssociationCollection $associations, array $levels)
+    {
+        $result = [];
+        foreach ($associations as $association) {
+            if (current($levels) !== $association->className()) {
+                continue;
+            }
+            $result[$association->name()] = [];
+
+            if (!next($levels)) {
+                continue;
+            }
+
+            $result[$association->name()] = $this->_containNestedAssociations(
+                $association->target()->associations(),
+                array_slice($levels, key($levels))
+            );
+        }
+
+        return $result;
+    }
+}

--- a/src/Events/EditViewListener.php
+++ b/src/Events/EditViewListener.php
@@ -1,0 +1,55 @@
+<?php
+namespace CsvMigrations\Events;
+
+use Cake\Event\Event;
+use Cake\ORM\Entity;
+use Cake\ORM\Query;
+use CsvMigrations\Events\BaseViewListener;
+
+class EditViewListener extends BaseViewListener
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function implementedEvents()
+    {
+        return [
+            'CsvMigrations.Edit.beforeFind' => 'beforeFind',
+            'CsvMigrations.Edit.afterFind' => 'afterFind',
+            'CsvMigrations.Edit.beforeSave' => 'beforeSave',
+            'CsvMigrations.Edit.afterSave' => 'afterSave'
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeFind(Event $event, Query $query)
+    {
+        $this->_lookupFields($query, $event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function afterFind(Event $event, Entity $entity)
+    {
+        // $this->_prettifyEntity($entity, $event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeSave(Event $event, Entity $entity)
+    {
+        $this->_associatedByLookupFields($entity, $event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function afterSave(Event $event, Entity $entity)
+    {
+        //
+    }
+}

--- a/src/Events/EditViewListener.php
+++ b/src/Events/EditViewListener.php
@@ -34,7 +34,7 @@ class EditViewListener extends BaseViewListener
      */
     public function afterFind(Event $event, Entity $entity)
     {
-        // $this->_prettifyEntity($entity, $event);
+        //
     }
 
     /**

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -27,11 +27,6 @@ class IndexViewListener extends BaseViewListener
     const FORMAT_PRETTY = 'pretty';
 
     /**
-     * Datatables format identifier
-     */
-    const FORMAT_DATATABLES = 'datatables';
-
-    /**
      * {@inheritDoc}
      */
     public function implementedEvents()

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -45,7 +45,7 @@ class IndexViewListener extends BaseViewListener
     {
         $query->contain($this->_getAssociations($event));
         $this->_filterByConditions($query, $event);
-        $this->_viewFields($query, $event);
+        $this->_selectActionFields($query, $event);
     }
 
     /**
@@ -98,7 +98,7 @@ class IndexViewListener extends BaseViewListener
      * @param  \Cake\Event\Event $event The event
      * @return void
      */
-    protected function _viewFields(Query $query, Event $event)
+    protected function _selectActionFields(Query $query, Event $event)
     {
         if (!in_array($event->subject()->request->query('format'), [static::FORMAT_DATATABLES])) {
             return;

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -182,6 +182,11 @@ class IndexViewListener extends BaseViewListener
         }
 
         $fields = $this->_getActionFields($event->subject()->request);
+
+        if (empty($fields)) {
+            return;
+        }
+
         $fields[] = static::MENU_PROPERTY_NAME;
 
         $primaryKey = $event->subject()->{$event->subject()->name}->primaryKey();

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -177,7 +177,7 @@ class IndexViewListener extends BaseViewListener
      */
     protected function _datatablesStructure(ResultSet $entities, Event $event)
     {
-        if (!in_array($event->subject()->request->query('format'), [static::FORMAT_DATATABLES])) {
+        if (static::FORMAT_DATATABLES !== $event->subject()->request->query('format')) {
             return;
         }
 

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -73,6 +73,9 @@ class IndexViewListener extends BaseViewListener
         $this->_datatablesStructure($entities, $event);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function _getActionFields(Request $request, $action = null)
     {
         $fields = parent::_getActionFields($request, $action);
@@ -92,7 +95,8 @@ class IndexViewListener extends BaseViewListener
     }
 
     /**
-     *
+     * Method that adds SELECT clause to the Query to only include
+     * action fields (as defined in the csv file).
      *
      * @param  \Cake\ORM\Query   $query Query object
      * @param  \Cake\Event\Event $event The event

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -1,0 +1,231 @@
+<?php
+namespace CsvMigrations\Events;
+
+use Cake\Event\Event;
+use Cake\Event\EventManager;
+use Cake\Network\Request;
+use Cake\ORM\Query;
+use Cake\ORM\ResultSet;
+use CsvMigrations\Events\BaseViewListener;
+
+
+class IndexViewListener extends BaseViewListener
+{
+    /**
+     * Include menus identifier
+     */
+    const FLAG_INCLUDE_MENUS = 'menus';
+
+    /**
+     * Property name for menu items
+     */
+    const MENU_PROPERTY_NAME = '_Menus';
+
+    /**
+     * Pretty format identifier
+     */
+    const FORMAT_PRETTY = 'pretty';
+
+    /**
+     * Datatables format identifier
+     */
+    const FORMAT_DATATABLES = 'datatables';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function implementedEvents()
+    {
+        return [
+            'CsvMigrations.Index.beforePaginate' => 'beforePaginate',
+            'CsvMigrations.Index.afterPaginate' => 'afterPaginate',
+            'CsvMigrations.Index.beforeRender' => 'beforeRender'
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforePaginate(Event $event, Query $query)
+    {
+        $query->contain($this->_getAssociations($event));
+        $this->_filterByConditions($query, $event);
+        $this->_viewFields($query, $event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function afterPaginate(Event $event, ResultSet $entities)
+    {
+        if ($entities->isEmpty()) {
+            return;
+        }
+
+        $this->_prettifyEntities($entities, $event);
+        $this->_includeMenus($entities, $event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeRender(Event $event, ResultSet $entities)
+    {
+        if ($entities->isEmpty()) {
+            return;
+        }
+
+        $this->_datatablesStructure($entities, $event);
+    }
+
+    protected function _getActionFields(Request $request, $action = null)
+    {
+        $fields = parent::_getActionFields($request, $action);
+
+        if (empty($fields)) {
+            return $fields;
+        }
+
+        foreach ($fields as &$field) {
+            if (!array($field)) {
+                continue;
+            }
+            $field = current($field);
+        }
+
+        return $fields;
+    }
+
+    /**
+     *
+     *
+     * @param  \Cake\ORM\Query   $query Query object
+     * @param  \Cake\Event\Event $event The event
+     * @return void
+     */
+    protected function _viewFields(Query $query, Event $event)
+    {
+        if (!in_array($event->subject()->request->query('format'), [static::FORMAT_DATATABLES])) {
+            return;
+        }
+
+        $fields = $this->_getActionFields($event->subject()->request);
+
+        if (empty($fields)) {
+            return;
+        }
+
+        $primaryKey = $event->subject()->{$event->subject()->name}->primaryKey();
+        // always include primary key, useful for menus URLs
+        if (!in_array($primaryKey, $fields)) {
+            array_push($fields, $primaryKey);
+        }
+
+        $query->select($fields, true);
+    }
+
+    /**
+     * Method that prepares entities to run through pretiffy logic.
+     *
+     * @param  \Cake\ORM\ResultSet $entities Entities
+     * @param  \Cake\Event\Event   $event    Event instance
+     * @return void
+     */
+    protected function _prettifyEntities(ResultSet $entities, Event $event)
+    {
+        if (!in_array($event->subject()->request->query('format'), [static::FORMAT_PRETTY, static::FORMAT_DATATABLES])) {
+            return;
+        }
+
+        $fields = [];
+        if (static::FORMAT_DATATABLES === $event->subject()->request->query('format')) {
+            $fields = $this->_getActionFields($event->subject()->request);
+        }
+
+        $tableName = $event->subject()->name;
+        foreach ($entities as $entity) {
+            $this->_prettify($entity, $tableName, $fields);
+        }
+    }
+
+    /**
+     * Method that retrieves and attaches menu elements to API response.
+     *
+     * @param  \Cake\ORM\ResultSet $entities Entities
+     * @param  \Cake\Event\Event   $event    Event instance
+     * @return void
+     */
+    protected function _includeMenus(ResultSet $entities, Event $event)
+    {
+        if (!$event->subject()->request->query(static::FLAG_INCLUDE_MENUS)) {
+            return;
+        }
+
+        foreach ($entities as $entity) {
+            // broadcast menu event
+            $ev = new Event('View.Index.Menu.Actions', $event->subject(), [
+                'request' => $event->subject()->request,
+                'options' => $entity
+            ]);
+            EventManager::instance()->dispatch($ev);
+
+            $entity->{static::MENU_PROPERTY_NAME} = $ev->result;
+        }
+    }
+
+    /**
+     * Method that re-formats entities to Datatables supported format.
+     *
+     * @param  \Cake\ORM\ResultSet $entities Entities
+     * @param  \Cake\Event\Event   $event    Event instance
+     * @return void
+     */
+    protected function _datatablesStructure(ResultSet $entities, Event $event)
+    {
+        if (!in_array($event->subject()->request->query('format'), [static::FORMAT_DATATABLES])) {
+            return;
+        }
+
+        $fields = $this->_getActionFields($event->subject()->request);
+        $fields[] = static::MENU_PROPERTY_NAME;
+
+        $primaryKey = $event->subject()->{$event->subject()->name}->primaryKey();
+        $unsetPrimaryKey = !in_array($primaryKey, $fields);
+        foreach ($entities as $entity) {
+            foreach ($fields as $k => $v) {
+                $entity->{$k} = $entity->{$v};
+                $entity->unsetProperty($v);
+            }
+
+            if ($unsetPrimaryKey) {
+                $entity->unsetProperty($primaryKey);
+            }
+        }
+    }
+
+    /**
+     * Method that filters ORM records by provided conditions.
+     *
+     * @param  \Cake\ORM\Query   $query Query object
+     * @param  \Cake\Event\Event $event The event
+     * @return void
+     */
+    protected function _filterByConditions(Query $query, Event $event)
+    {
+        if (empty($event->subject()->request->query('conditions'))) {
+            return;
+        }
+
+        $conditions = [];
+        $tableName = $event->subject()->name;
+        foreach ($event->subject()->request->query('conditions') as $k => $v) {
+            if (false === strpos($k, '.')) {
+                $k = $tableName . '.' . $k;
+            }
+
+            $conditions[$k] = $v;
+        };
+
+        $query->applyOptions(['conditions' => $conditions]);
+    }
+}

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -8,7 +8,6 @@ use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
 use CsvMigrations\Events\BaseViewListener;
 
-
 class IndexViewListener extends BaseViewListener
 {
     /**
@@ -85,10 +84,7 @@ class IndexViewListener extends BaseViewListener
         }
 
         foreach ($fields as &$field) {
-            if (!array($field)) {
-                continue;
-            }
-            $field = current($field);
+            $field = current((array)$field);
         }
 
         return $fields;

--- a/src/Events/ViewMenuListener.php
+++ b/src/Events/ViewMenuListener.php
@@ -108,6 +108,7 @@ class ViewMenuListener implements EventListenerInterface
         $displayField = TableRegistry::get($controllerName)->displayField();
 
         $urlView = [
+            'prefix' => false,
             'plugin' => $request->plugin,
             'controller' => $request->controller,
             'action' => 'view',
@@ -120,6 +121,7 @@ class ViewMenuListener implements EventListenerInterface
         );
 
         $urlEdit = [
+            'prefix' => false,
             'plugin' => $request->plugin,
             'controller' => $request->controller,
             'action' => 'edit',
@@ -132,6 +134,7 @@ class ViewMenuListener implements EventListenerInterface
         );
 
         $urlDel = [
+            'prefix' => false,
             'plugin' => $request->plugin,
             'controller' => $request->controller,
             'action' => 'delete',

--- a/src/Events/ViewMenuListener.php
+++ b/src/Events/ViewMenuListener.php
@@ -1,6 +1,7 @@
 <?php
 namespace CsvMigrations\Events;
 
+use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use Cake\Network\Request;
@@ -12,6 +13,11 @@ use CsvMigrations\View\AppView;
 
 class ViewMenuListener implements EventListenerInterface
 {
+    /**
+     * Event listener type
+     */
+    const EVENT_TYPE = 'menus';
+
     /**
      * Menu element name
      */
@@ -29,13 +35,20 @@ class ViewMenuListener implements EventListenerInterface
      */
     public function implementedEvents()
     {
-        return [
-            'View.Index.Menu.Top' => 'getIndexMenuTop',
-            'View.Index.Menu.Actions' => 'getIndexMenuActions',
-            'View.Associated.Menu.Actions' => 'getAssociatedMenuActions',
-            'View.View.Menu.Top' => 'getViewMenuTop',
-            'View.View.Menu.Top.Row' => 'getViewMenuTopRow',
-        ];
+        $menus = Configure::read('CsvMigrations.menus');
+        $events = Configure::read('CsvMigrations.events');
+
+        $result = [];
+        foreach ($events as $type) {
+            if (empty($type[static::EVENT_TYPE])) {
+                continue;
+            }
+            foreach ($type[static::EVENT_TYPE] as $key => $value) {
+                $result[key($value)] = current($value);
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Events/ViewMenuListener.php
+++ b/src/Events/ViewMenuListener.php
@@ -169,7 +169,10 @@ class ViewMenuListener implements EventListenerInterface
         ];
 
         if ($appView->elementExists(static::MENU_ELEMENT)) {
-            $result = $appView->element(static::MENU_ELEMENT, ['menu' => $menu, 'renderAs' => 'provided']);
+            $result = $appView->element(
+                static::MENU_ELEMENT,
+                ['menu' => $menu, 'renderAs' => 'provided', 'user' => $event->subject()->Auth->user()]
+            );
         } else {
             $result = $btnView . $btnEdit . $btnDel;
         }

--- a/src/Events/ViewMenuListener.php
+++ b/src/Events/ViewMenuListener.php
@@ -1,7 +1,6 @@
 <?php
 namespace CsvMigrations\Events;
 
-use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use Cake\Network\Request;
@@ -35,20 +34,13 @@ class ViewMenuListener implements EventListenerInterface
      */
     public function implementedEvents()
     {
-        $menus = Configure::read('CsvMigrations.menus');
-        $events = Configure::read('CsvMigrations.events');
-
-        $result = [];
-        foreach ($events as $type) {
-            if (empty($type[static::EVENT_TYPE])) {
-                continue;
-            }
-            foreach ($type[static::EVENT_TYPE] as $key => $value) {
-                $result[key($value)] = current($value);
-            }
-        }
-
-        return $result;
+        return [
+            'View.Index.Menu.Top' => 'getIndexMenuTop',
+            'View.Index.Menu.Actions' => 'getIndexMenuActions',
+            'View.View.Menu.Top' => 'getViewMenuTop',
+            'View.View.Menu.Top.Row' => 'getViewMenuTopRow',
+            'View.Associated.Menu.Actions' => 'getAssociatedMenuActions'
+        ];
     }
 
     /**

--- a/src/Events/ViewViewListener.php
+++ b/src/Events/ViewViewListener.php
@@ -1,0 +1,59 @@
+<?php
+namespace CsvMigrations\Events;
+
+use Cake\Event\Event;
+use Cake\ORM\Entity;
+use Cake\ORM\Query;
+use CsvMigrations\Events\BaseViewListener;
+
+class ViewViewListener extends BaseViewListener
+{
+    /**
+     * Pretty format identifier
+     */
+    const FORMAT_PRETTY = 'pretty';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function implementedEvents()
+    {
+        return [
+            'CsvMigrations.View.beforeFind' => 'beforeFind',
+            'CsvMigrations.View.afterFind' => 'afterFind'
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeFind(Event $event, Query $query)
+    {
+        $this->_lookupFields($query, $event);
+        $query->contain($this->_getAssociations($event));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function afterFind(Event $event, Entity $entity)
+    {
+        $this->_prettifyEntity($entity, $event);
+    }
+
+    /**
+     * Method that prepares entity to run through pretiffy logic.
+     *
+     * @param  \Cake\ORM\Entity  $entity Entity
+     * @param  \Cake\Event\Event $event  Event instance
+     * @return void
+     */
+    protected function _prettifyEntity(Entity $entity, Event $event)
+    {
+        if (!in_array($event->subject()->request->query('format'), [static::FORMAT_PRETTY])) {
+            return;
+        }
+
+        $this->_prettify($entity, $event->subject()->name, []);
+    }
+}

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -133,6 +133,7 @@ class RelatedFieldHandler extends BaseFieldHandler
                 $inputs[] = $this->cakeView->Html->link(
                     h($properties['dispFieldVal']),
                     $this->cakeView->Url->build([
+                        'prefix' => false,
                         'plugin' => $properties['plugin'],
                         'controller' => $properties['controller'],
                         'action' => static::LINK_ACTION,

--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -69,13 +69,6 @@ trait RelatedFieldTrait
             : null;
         // get plugin and controller names
         list($result['plugin'], $result['controller']) = pluginSplit($tableName);
-        // remove vendor from plugin name
-        if (!is_null($result['plugin'])) {
-            $pos = strpos($result['plugin'], '/');
-            if ($pos !== false) {
-                $result['plugin'] = substr($result['plugin'], $pos + 1);
-            }
-        }
 
         return $result;
     }

--- a/src/PrettifyTrait.php
+++ b/src/PrettifyTrait.php
@@ -32,6 +32,11 @@ trait PrettifyTrait
         }
 
         foreach ($fields as $field) {
+            // skip fields that are not set in the current entity
+            if (!isset($entity->{$field})) {
+                continue;
+            }
+
             $renderOptions = ['entity' => $entity];
             $entity->{$field} = $this->__fhf->renderValue(
                 $tableName,

--- a/src/Table.php
+++ b/src/Table.php
@@ -127,8 +127,13 @@ class Table extends BaseTable
             return $query;
         }
 
+        $tableName = $this->alias();
         // check for record by table's lookup fields
         foreach ($lookupFields as $lookupField) {
+            // prepend table name to avoid CakePHP ORM's ambiguous column errors
+            if (false === strpos($lookupField, '.')) {
+                $lookupField = $tableName . '.' . $lookupField;
+            }
             $query->orWhere([$lookupField => $id]);
         }
 

--- a/src/Template/Common/index.ctp
+++ b/src/Template/Common/index.ctp
@@ -1,6 +1,5 @@
 <?php
 $options = array(
-    'entities' => $entities,
     'fields' => $fields
 );
 echo $this->element('CsvMigrations.View/index', [

--- a/src/Template/Element/View/add.ctp
+++ b/src/Template/Element/View/add.ctp
@@ -30,6 +30,12 @@ $formOptions = [
         'controller' => $this->request->controller,
         'action' => $this->request->action
     ],
+    'data-panels_url' => $this->Url->build([
+        'prefix' => 'api',
+        'plugin' => $this->request->plugin,
+        'controller' => $this->request->controller,
+        'action' => 'panels'
+    ]),
     'name' => Inflector::dasherize($moduleAlias),
 ];
 if (!empty($this->request->query['embedded'])) {

--- a/src/Template/Element/View/add.ctp
+++ b/src/Template/Element/View/add.ctp
@@ -30,7 +30,7 @@ $formOptions = [
         'controller' => $this->request->controller,
         'action' => $this->request->action
     ],
-    'data-panels_url' => $this->Url->build([
+    'data-panels-url' => $this->Url->build([
         'prefix' => 'api',
         'plugin' => $this->request->plugin,
         'controller' => $this->request->controller,

--- a/src/Template/Element/View/edit.ctp
+++ b/src/Template/Element/View/edit.ctp
@@ -29,6 +29,12 @@ $formOptions = [
         'controller' => $this->request->controller,
         'action' => $this->request->action
     ],
+    'data-panels_url' => $this->Url->build([
+        'prefix' => 'api',
+        'plugin' => $this->request->plugin,
+        'controller' => $this->request->controller,
+        'action' => 'panels'
+    ]),
     'name' => Inflector::dasherize($moduleAlias),
 ];
 if (!empty($this->request->query['embedded'])) {

--- a/src/Template/Element/View/edit.ctp
+++ b/src/Template/Element/View/edit.ctp
@@ -29,7 +29,7 @@ $formOptions = [
         'controller' => $this->request->controller,
         'action' => $this->request->action
     ],
-    'data-panels_url' => $this->Url->build([
+    'data-panels-url' => $this->Url->build([
         'prefix' => 'api',
         'plugin' => $this->request->plugin,
         'controller' => $this->request->controller,

--- a/src/Template/Element/View/index.ctp
+++ b/src/Template/Element/View/index.ctp
@@ -21,9 +21,8 @@ echo $this->Html->scriptBlock(
         api_ext: \'json\',
         api_token: ' . json_encode(Configure::read('CsvMigrations.api.token')) . ',
         fields: '. json_encode($options['fields']) . ',
-        menus: ' . json_encode($menus) . ',
         format: \'pretty\',
-        menu_property: \'' . Configure::read('CsvMigrations.api.menus_property') . '\'
+        menus: true,
     });',
     ['block' => 'scriptBottom']
 );
@@ -74,9 +73,7 @@ if (empty($options['title'])) {
                     <?php foreach ($options['fields'] as $field) : ?>
                         <th><?= Inflector::humanize($field[0]['name']); ?></th>
                     <?php endforeach; ?>
-                    <?php foreach ($menus as $menu) : ?>
-                        <th><?= Inflector::humanize($menu); ?></th>
-                    <?php endforeach; ?>
+                    <th><?= __('Actions'); ?></th>
                     </tr>
                 </thead>
             </table>

--- a/src/Template/Element/View/index.ctp
+++ b/src/Template/Element/View/index.ctp
@@ -20,9 +20,8 @@ echo $this->Html->scriptBlock(
         ]) . '\',
         api_ext: \'json\',
         api_token: ' . json_encode(Configure::read('CsvMigrations.api.token')) . ',
-        fields: '. json_encode($options['fields']) . ',
-        format: \'pretty\',
         menus: true,
+        format: \'datatables\'
     });',
     ['block' => 'scriptBottom']
 );

--- a/src/Template/Element/associated_records.ctp
+++ b/src/Template/Element/associated_records.ctp
@@ -135,7 +135,7 @@ if (!empty($csvAssociatedRecords['manyToMany'])) {
 
             <?php if (!empty($assocData['records'])) : ?>
                 <div class=" table-responsive">
-                    <table class="table table-hover table-datatable">
+                    <table class="table table-hover">
                         <thead>
                             <tr>
                             <?php foreach ($assocData['fields'] as $assocField) : ?>
@@ -257,10 +257,6 @@ if (!empty($embFields)) :
  * - load these files only if foreign/related field exists
  */
 echo $this->element('CsvMigrations.common_js_libs');
-
-echo $this->Html->css('CsvMigrations.datatables.min', ['block' => 'cssBottom']);
-echo $this->Html->script('CsvMigrations.datatables.min', ['block' => 'scriptBottom']);
-echo $this->Html->script('CsvMigrations.data-tables', ['block' => 'scriptBottom']);
 ?>
 <?php endif; ?>
 

--- a/src/Template/Element/common_js_libs.ctp
+++ b/src/Template/Element/common_js_libs.ctp
@@ -10,13 +10,13 @@ echo $this->Html->scriptBlock(
     'typeahead_options = ' . json_encode(
         array_merge(
             Configure::read('CsvMigrations.typeahead'),
-            Configure::read('API')
+            Configure::read('CsvMigrations.api')
         )
     ) . ';',
     ['block' => 'scriptBottom']
 );
 echo $this->Html->scriptBlock(
-    'api_options = ' . json_encode(Configure::read('API')) . ';',
+    'api_options = ' . json_encode(Configure::read('CsvMigrations.api')) . ';',
     ['block' => 'scriptBottom']
 );
 echo $this->Html->script('CsvMigrations.typeahead', ['block' => 'scriptBottom']);

--- a/webroot/js/data-tables.js
+++ b/webroot/js/data-tables.js
@@ -1,8 +1,0 @@
-(function($) {
-    $(document).ready(function() {
-        $('.table-datatable').DataTable({
-            paging: false,
-            searching: false
-        });
-    });
-})(jQuery);

--- a/webroot/js/panels.js
+++ b/webroot/js/panels.js
@@ -3,8 +3,8 @@
 
     var Panel = function(form) {
         this.form = form;
-        this.module = form.attr('name');
-        if (!this.form || !this.module) {
+        this.url = $(form).data('panels_url');
+        if (!this.form || !this.url) {
             return false;
         }
 
@@ -77,11 +77,10 @@
 
     Panel.prototype.evaluateWithServer = function() {
         var $form = this.form;
-        var url = '/api/' + this.module + '/panels/';
         var token = api_options.token;
         var that = this;
         $.ajax({
-            url: url,
+            url: that.url,
             type: 'POST',
             data: that.buildData(),
             dataType: 'json',

--- a/webroot/js/panels.js
+++ b/webroot/js/panels.js
@@ -3,7 +3,7 @@
 
     var Panel = function(form) {
         this.form = form;
-        this.url = $(form).data('panels_url');
+        this.url = $(form).data('panels-url');
         if (!this.form || !this.url) {
             return false;
         }

--- a/webroot/js/view-index.js
+++ b/webroot/js/view-index.js
@@ -18,17 +18,14 @@ var view_index = view_index || {};
         this.api_ext = options.hasOwnProperty('api_ext') ? options.api_ext : null;
         this.api_token = options.hasOwnProperty('api_token') ? options.api_token : null;
         this.table_id = options.hasOwnProperty('table_id') ? options.table_id : null;
-        this.fields = options.hasOwnProperty('fields') ? options.fields : {};
-        this.menus = options.hasOwnProperty('menus') ? options.menus : {};
+        this.menus = options.hasOwnProperty('menus') ? options.menus : false;
         this.format = options.hasOwnProperty('format') ? options.format : {};
-        this.menu_property = options.hasOwnProperty('menu_property') ? options.menu_property : null;
 
         this.datatable();
     };
 
     ViewIndex.prototype.datatable = function() {
         var that = this;
-        var columns = this._getTableColumns();
 
         $(this.table_id).DataTable({
             searching: false,
@@ -40,7 +37,7 @@ var view_index = view_index || {};
                     'Authorization': 'Bearer ' + that.api_token
                 },
                 data: function(d) {
-                    if (!jQuery.isEmptyObject(that.menus)) {
+                    if (that.menus) {
                         d.menus = that.menus;
                     }
                     if (!jQuery.isEmptyObject(that.format)) {
@@ -58,34 +55,8 @@ var view_index = view_index || {};
 
                     return JSON.stringify(d);
                 }
-            },
-            columns: columns
-        });
-    };
-
-    /**
-     * Method that organizes data fields in a columns array format
-     * that is recognizable by DataTables, to be used as column data points.
-     *
-     * @link            https://www.datatables.net/manual/ajax
-     * @return {object} Data columns
-     */
-    ViewIndex.prototype._getTableColumns = function() {
-        var result = [];
-
-        for (var k in this.fields) {
-            result.push({'data': this.fields[k][0].name});
-        }
-
-        for (var j in this.menus) {
-            var prefix = null;
-            if (this.menu_property) {
-                prefix = this.menu_property + '.';
             }
-            result.push({'data': prefix + this.menus[j]});
-        }
-
-        return result;
+        });
     };
 
     view_index = new ViewIndex();

--- a/webroot/js/view-index.js
+++ b/webroot/js/view-index.js
@@ -1,0 +1,93 @@
+var view_index = view_index || {};
+
+(function($) {
+    /**
+     * View Index Logic.
+     *
+     * @param {object} options
+     */
+    function ViewIndex() {}
+
+    /**
+     * Initialize method.
+     *
+     * @return {void}
+     */
+    ViewIndex.prototype.init = function(options) {
+        this.api_url = options.hasOwnProperty('api_url') ? options.api_url : null;
+        this.api_ext = options.hasOwnProperty('api_ext') ? options.api_ext : null;
+        this.api_token = options.hasOwnProperty('api_token') ? options.api_token : null;
+        this.table_id = options.hasOwnProperty('table_id') ? options.table_id : null;
+        this.fields = options.hasOwnProperty('fields') ? options.fields : {};
+        this.menus = options.hasOwnProperty('menus') ? options.menus : {};
+        this.format = options.hasOwnProperty('format') ? options.format : {};
+        this.menu_property = options.hasOwnProperty('menu_property') ? options.menu_property : null;
+
+        this.datatable();
+    };
+
+    ViewIndex.prototype.datatable = function() {
+        var that = this;
+        var columns = this._getTableColumns();
+
+        $(this.table_id).DataTable({
+            searching: false,
+            processing: true,
+            serverSide: true,
+            ajax: {
+                url: that.api_url + '.' + that.api_ext,
+                headers: {
+                    'Authorization': 'Bearer ' + that.api_token
+                },
+                data: function(d) {
+                    if (!jQuery.isEmptyObject(that.menus)) {
+                        d.menus = that.menus;
+                    }
+                    if (!jQuery.isEmptyObject(that.format)) {
+                        d.format = that.format;
+                    }
+                    d.limit = d.length;
+                    d.page = 1 + d.start / d.length;
+
+                    return d;
+                },
+                dataFilter: function(d) {
+                    d = jQuery.parseJSON(d);
+                    d.recordsTotal = d.pagination.count;
+                    d.recordsFiltered = d.pagination.count;
+
+                    return JSON.stringify(d);
+                }
+            },
+            columns: columns
+        });
+    };
+
+    /**
+     * Method that organizes data fields in a columns array format
+     * that is recognizable by DataTables, to be used as column data points.
+     *
+     * @link            https://www.datatables.net/manual/ajax
+     * @return {object} Data columns
+     */
+    ViewIndex.prototype._getTableColumns = function() {
+        var result = [];
+
+        for (var k in this.fields) {
+            result.push({'data': this.fields[k][0].name});
+        }
+
+        for (var j in this.menus) {
+            var prefix = null;
+            if (this.menu_property) {
+                prefix = this.menu_property + '.';
+            }
+            result.push({'data': prefix + this.menus[j]});
+        }
+
+        return result;
+    };
+
+    view_index = new ViewIndex();
+
+})(jQuery);


### PR DESCRIPTION
:warning: **Backward compatibility breaker**

On index View no records are fetched server-side, but instead, they are fetched using API call from DataTables library. This brought changes all over the plugin's code.

On API interface the Auth component is now always enabled but will allow access to all actions if the API authentication flag is _off_. This allows the following logic to work:
If API authentication is set to _on_, access is restricted to `token()` action for validating the user and generating an API token. If API authentication is set to _off_, access is allowed to all API actions (not recommended, but optional for systems where IP access restrictions are in place and want to skip API authentication). The plugin always generates an API token for the system's currently logged in user. This token is passed to all ajax calls made within the system (for example the DataTables library mentioned above), so the user can be verified and used by any third party ACL libraries.

In addition, API responses can now include UI menus, such as action buttons on the index view (view, edit, delete), which again can be filtered through third party ACL libraries.