### PR TITLE
Implemented BLOB field handler (task #2706)

### DIFF
--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -25,6 +25,7 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
      */
     protected $_fieldTypes = [
         'text' => 'textarea',
+        'blob' => 'textarea',
         'string' => 'text',
         'uuid' => 'text',
         'integer' => 'number',

--- a/src/FieldHandlers/BlobFieldHandler.php
+++ b/src/FieldHandlers/BlobFieldHandler.php
@@ -1,0 +1,44 @@
+<?php
+namespace CsvMigrations\FieldHandlers;
+
+use CsvMigrations\FieldHandlers\BaseFieldHandler;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class BlobFieldHandler extends BaseFieldHandler
+{
+    /**
+     * {@inheritDoc}
+     * In addtion, it sets the limit to Phinx\Db\Adapter\MysqlAdapter::TEXT_LONG
+     */
+    public function fieldToDb(CsvField $csvField)
+    {
+        $dbFields[] = new DbField(
+            $csvField->getName(),
+            $csvField->getType(),
+            MysqlAdapter::BLOB_LONG,
+            $csvField->getRequired(),
+            $csvField->getNonSearchable(),
+            $csvField->getUnique()
+        );
+
+        return $dbFields;
+    }
+
+    /**
+     * Render value as-is
+     *
+     * @todo Add support for encoding (base64, etc) via $options
+     *
+     * @param  mixed  $table   name or instance of the Table
+     * @param  string $field   field name
+     * @param  string $data    field data
+     * @param  array  $options field options
+     * @return string
+     */
+    public function renderValue($table, $field, $data, array $options = [])
+    {
+        $result = $data;
+
+        return $result;
+    }
+}

--- a/src/FieldHandlers/DbField.php
+++ b/src/FieldHandlers/DbField.php
@@ -55,6 +55,7 @@ class DbField
         'decimal' => ['precision' => 10, 'scale' => 2],
         'boolean' => [],
         'text' => [],
+        'blob' => [],
         'datetime' => [],
         'date' => [],
         'time' => [],

--- a/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace CsvMigrations\Test\TestCase\FieldHandlers;
+
+use CsvMigrations\FieldHandlers\BlobFieldHandler;
+use PHPUnit_Framework_TestCase;
+
+class BlobFieldHandlerTest extends PHPUnit_Framework_TestCase
+{
+    protected $fh;
+
+    protected function setUp()
+    {
+        $this->fh = new BlobFieldHandler();
+    }
+
+    public function testInterface()
+    {
+        $implementedInterfaces = array_keys(class_implements($this->fh));
+        $this->assertTrue(in_array('CsvMigrations\FieldHandlers\FieldHandlerInterface', $implementedInterfaces), "FieldHandlerInterface is not implemented");
+    }
+
+    public function getValues()
+    {
+        return [
+            [true, 'Boolean true'],
+            [false, 'Boolean false'],
+            [0, 'Integer zero'],
+            [1, 'Positive integer'],
+            [-1, 'Negative integer'],
+            [1.501, 'Positive float'],
+            [-1.501, 'Negative float'],
+            ['', 'Empty string'],
+            ['foobar', 'String'],
+            ['2017-07-05', 'Date'],
+        ];
+    }
+
+    /**
+     * @dataProvider getValues
+     */
+    public function testRenderValue($value, $description)
+    {
+        $result = $this->fh->renderValue(null, null, $value, []);
+        $this->assertEquals($value, $result, "Value rendering is broken for: $description");
+    }
+}


### PR DESCRIPTION
Blob field works exactly as the Text field (using MySQL's LONG_BLOB
type), except that when the value of the field is rendered, it is
returned as is, to avoid issues like formatting, encoding, etc.