### PR TITLE
fixed i18n time for datepickers (task #2757)

### DIFF
--- a/src/FieldHandlers/DateFieldHandler.php
+++ b/src/FieldHandlers/DateFieldHandler.php
@@ -1,7 +1,7 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
-use Cake\I18n\Date;
+use Cake\I18n\Time;
 use CsvMigrations\FieldHandlers\BaseFieldHandler;
 
 class DateFieldHandler extends BaseFieldHandler
@@ -32,7 +32,7 @@ class DateFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
-        if ($data instanceof Date) {
+        if ($data instanceof Time) {
             $data = $data->i18nFormat(static::DATE_FORMAT);
         }
 

--- a/src/FieldHandlers/DatetimeFieldHandler.php
+++ b/src/FieldHandlers/DatetimeFieldHandler.php
@@ -1,7 +1,7 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
-use Cake\I18n\Date;
+use Cake\I18n\Time;
 use CsvMigrations\FieldHandlers\BaseFieldHandler;
 
 class DatetimeFieldHandler extends BaseFieldHandler
@@ -32,7 +32,7 @@ class DatetimeFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
-        if ($data instanceof Date) {
+        if ($data instanceof Time) {
             $data = $data->i18nFormat(static::DATETIME_FORMAT);
         }
 

--- a/src/FieldHandlers/ReminderFieldHandler.php
+++ b/src/FieldHandlers/ReminderFieldHandler.php
@@ -1,7 +1,6 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
-use Cake\I18n\Date;
 use CsvMigrations\FieldHandlers\DatetimeFieldHandler;
 
 class ReminderFieldHandler extends DatetimeFieldHandler


### PR DESCRIPTION
Working with datepicker, JS goes crazy if it receives Date parameter (which is an Object).
Thus, we use `Cake\I18n\Time` for working with string argument