### PR TITLE
Fix broken file associations (task #2699)

### DIFF
--- a/src/Events/BaseViewListener.php
+++ b/src/Events/BaseViewListener.php
@@ -186,30 +186,29 @@ abstract class BaseViewListener implements EventListenerInterface
     {
         $result = [];
 
-        if (!$event->subject()->request->query('associated')) {
-            return $result;
-        }
-
-        $table = $event->subject()->{$event->subject()->name};
-        $associations = $table->associations();
+        $associations = $event->subject()->{$event->subject()->name}->associations();
 
         if (empty($associations)) {
             return $result;
         }
 
+        // always include file associations
         $result = $this->_containAssociations(
             $associations,
-            $this->_nestedAssociations
+            $this->_fileAssociations,
+            true
         );
 
-        // always include file associations
+        if (!$event->subject()->request->query('associated')) {
+            return $result;
+        }
+
         $result = array_merge(
-            $result,
             $this->_containAssociations(
                 $associations,
-                $this->_fileAssociations,
-                true
-            )
+                $this->_nestedAssociations
+            ),
+            $result
         );
 
         return $result;

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -56,6 +56,11 @@ class IndexViewListener extends BaseViewListener
             return;
         }
 
+        // @todo temporary functionality, please see _includeFiles() method documentation.
+        foreach ($entities as $entity) {
+            $this->_includeFiles($entity, $event);
+        }
+
         $this->_prettifyEntities($entities, $event);
         $this->_includeMenus($entities, $event);
     }

--- a/src/Events/ViewViewListener.php
+++ b/src/Events/ViewViewListener.php
@@ -38,6 +38,9 @@ class ViewViewListener extends BaseViewListener
      */
     public function afterFind(Event $event, Entity $entity)
     {
+        // @todo temporary functionality, please see _includeFiles() method documentation.
+        $this->_includeFiles($entity, $event);
+
         $this->_prettifyEntity($entity, $event);
     }
 


### PR DESCRIPTION
There is an issue with associated files when fetching records through the API. The problem started once we introduced the soft delete functionality. For the soft delete we are using [this](https://github.com/UseMuffin/Trash) plugin. It turned out that enabling the Trash behavior in our Tables it affects find queries with contained BelongsTo associations.

To overcome this issue we are currently fetching the associated record files using a more direct (hardcoded) method. Once the issue is resolved these commits can be reverted.