### PR TITLE
Read stream if BLOB value is a resource (task #2706)

### DIFF
--- a/src/FieldHandlers/BlobFieldHandler.php
+++ b/src/FieldHandlers/BlobFieldHandler.php
@@ -38,6 +38,9 @@ class BlobFieldHandler extends BaseFieldHandler
     public function renderValue($table, $field, $data, array $options = [])
     {
         $result = $data;
+        if (is_resource($data)) {
+            $result = stream_get_contents($data);
+        }
 
         return $result;
     }


### PR DESCRIPTION
CakePHP 3 tries to preserve memory when working with BLOB
database fields, and thus returns a resource instead of the
content of the field.

This fix checks if the value is a resource, and if it is,
`stream_get_contents()` is used to fetch the data.