### PR TITLE
Removed legacy CSV validations from CsvViewComponent (task #2584)

### DIFF
--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -28,11 +28,6 @@ class CsvViewComponent extends Component
     const ASSOC_FIELDS_ACTION = 'index';
 
     /**
-     * Count of fields per row for panel logic
-     */
-    const PANEL_COUNT = 3;
-
-    /**
      * Default configuration.
      * @var array
      */
@@ -67,14 +62,6 @@ class CsvViewComponent extends Component
      * @var array
      */
     protected $_panelActions = ['add', 'edit', 'view'];
-
-    /**
-     * Error messages.
-     * @var array
-     */
-    protected $_errorMessages = [
-        '_arrangePanels' => 'Field parameters count [%s] does not match required parameters count [%s]'
-    ];
 
     /**
      * Called before the controller action. You can use this method to configure and customize components
@@ -435,12 +422,6 @@ class CsvViewComponent extends Component
         $result = [];
 
         foreach ($data as $fields) {
-            $fieldCount = count($fields);
-            if (static::PANEL_COUNT !== $fieldCount) {
-                throw new RuntimeException(
-                    sprintf($this->_errorMessages[__FUNCTION__], $fieldCount, static::PANEL_COUNT)
-                );
-            }
             $panel = array_shift($fields);
             $result[$panel['name']][] = $fields;
         }


### PR DESCRIPTION
Since the implementation of the CSV parsers, there is no need to
validate the CSV views.  They will always return usable results.

This check was causing unnecessary exceptions (Errror 500), where
the parsed CSV could be actually rendered.