### PR TITLE
Get associated file ids from files table first (task #2857)

### DIFF
--- a/src/FileUploadsUtils.php
+++ b/src/FileUploadsUtils.php
@@ -175,8 +175,13 @@ class FileUploadsUtils
      */
     public function getFiles($data)
     {
+        $ids = $this->_fileAssociation->find('list', [
+            'valueField' => $this->_fileForeignKey,
+            'conditions' => [$this->_documentForeignKey => $data]
+        ])->toArray();
+
         $query = $this->_fileStorageAssociation->find('all', [
-            'conditions' => [$this->_fileStorageForeignKey => $data]
+            'conditions' => [$this->_fileStorageAssociation->primaryKey() . ' IN' => array_values($ids)]
         ]);
 
         return $query->all();


### PR DESCRIPTION
Fetching record files using foreign_key field is inconsistent between the different implementations. As a workaround we are using the files table to fetch file_id values according to document_id value and then pass the to file_storage find query.