### PR TITLE
giving more space for title

### DIFF
--- a/src/Template/Element/View/view.ctp
+++ b/src/Template/Element/View/view.ctp
@@ -53,10 +53,10 @@ if (empty($options['title'])) {
     <div class="col-xs-12">
         <?php if (empty($this->request->query['embedded'])) : ?>
         <div class="row">
-            <div class="col-xs-6">
+            <div class="col-xs-8">
                 <h3><strong><?= $options['title'] ?></strong></h3>
             </div>
-            <div class="col-xs-6">
+            <div class="col-xs-4">
                 <div class="h3 text-right">
                 <?php
                     $event = new Event('View.View.Menu.Top', $this, [


### PR DESCRIPTION
Long title jump on the second line, and currently the default icons on the right of the title occupy lot of place. Providing title a bit more space to fit long string on one line.