### PR TITLE
moved tabbed associations to the events (task #3007)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -9,6 +9,7 @@ use CsvMigrations\Events\IndexViewListener;
 use CsvMigrations\Events\ViewMenuListener;
 use CsvMigrations\Events\ViewViewListener;
 use CsvMigrations\Events\ReportListener;
+use CsvMigrations\Events\ViewViewTabsListener;
 
 Configure::write('CsvMigrations.actions', ['index', 'view', 'add', 'edit']);
 Configure::write('CsvMigrations.migrations.path', CONFIG . 'CsvMigrations' . DS . 'migrations' . DS);
@@ -34,6 +35,7 @@ EventManager::instance()->on(new IndexViewListener());
 EventManager::instance()->on(new ViewMenuListener());
 EventManager::instance()->on(new ViewViewListener());
 EventManager::instance()->on(new ReportListener());
+EventManager::instance()->on(new ViewViewTabsListener());
 
 //Load upload plugin configuration
 include 'file_storage.php';

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -92,7 +92,6 @@ trait ConfigurationTrait
         $path = $pathFinder->find(Inflector::camelize($tableName));
         $parser = new Parser();
         $this->_config = $parser->parseFromPath($path);
-
         // display field from configuration file
         if (isset($this->_config['table']['display_field']) && method_exists($this, 'displayField')) {
             $this->displayField($this->_config['table']['display_field']);
@@ -122,8 +121,8 @@ trait ConfigurationTrait
             $this->hiddenAssociations($this->_config['associations']['hide_associations']);
         }
 
-        if (isset($this->_config['associations']['association_labels'])) {
-            $this->associationLabels($this->_config['associations']['association_labels']);
+        if (isset($this->_config['associationLabels'])) {
+            $this->associationLabels($this->_config['associationLabels']);
         }
 
         if (isset($this->_config['parent']['module'])) {
@@ -186,12 +185,11 @@ trait ConfigurationTrait
      * @param array $fields received from CSV
      * @return array
      */
-    public function associationLabels($fields = null)
+    public function associationLabels($fields = [])
     {
-        if ($fields !== null) {
-            foreach ($fields as $field) {
-                list($associationName, $associationLabel) = explode(',', $field);
-                $this->_associationLabels[$associationName] = $associationLabel;
+        if (!empty($fields)) {
+            foreach ($fields as $name => $label) {
+                $this->_associationLabels[$name] = $label;
             }
         }
 

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -183,13 +183,13 @@ trait ConfigurationTrait
 
     /**
      * Return association labels if any present
-     * @param array $fields
+     * @param array $fields received from CSV
      * @return array
      */
     public function associationLabels($fields = null)
     {
         if ($fields !== null) {
-            foreach($fields as $field) {
+            foreach ($fields as $field) {
                 list($associationName, $associationLabel) = explode(',', $field);
                 $this->_associationLabels[$associationName] = $associationLabel;
             }
@@ -201,7 +201,7 @@ trait ConfigurationTrait
     /**
      * Return the list of hidden Associations for the config
      * file
-     * @param string|null $fields
+     * @param string|null $fields received
      * @return array
      */
     public function hiddenAssociations($fields = null)
@@ -209,6 +209,7 @@ trait ConfigurationTrait
         if ($fields !== null) {
             $this->_hiddenAssociations = explode(',', $fields);
         }
+
         return $this->_hiddenAssociations;
     }
 
@@ -233,12 +234,12 @@ trait ConfigurationTrait
 
 
     /**
-    * CSV Table might have a parent
-    * that helps us redirect things on working
-    * with modal forms.
-    * @param string $field
-    * @return string
-    */
+     * CSV Table might have a parent
+     * that helps us redirect things on working
+     * with modal forms.
+     * @param string $field received
+     * @return string
+     */
     public function parentField($field = null)
     {
         if ($field !== null) {
@@ -253,7 +254,7 @@ trait ConfigurationTrait
      *
      * Sets Table's virtual fields as an associated array with the
      * virtual field name as the key and the db fields name as value.
-     *
+     * @param array|null $fields passed to method from CSV
      * @return void
      */
     public function setVirtualFields(array $fields = [])

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -33,8 +33,20 @@ trait ConfigurationTrait
      * Each table might have a parent
      * @var string
      */
-    protected $_parentField;
+    protected $_parentModuleField;
 
+    /**
+     * relation field that identifies parent_id field
+     * @var string
+     */
+    protected $_parentRelationField;
+
+    /**
+     * redirect flag whether it should be self|parent
+     * to identify where to redirect
+     * @var string
+     */
+    protected $_parentRedirectField;
 
     /**
      * Typeahead fields used for searching in related fields
@@ -125,8 +137,8 @@ trait ConfigurationTrait
             $this->associationLabels($this->_config['associationLabels']);
         }
 
-        if (isset($this->_config['parent']['module'])) {
-            $this->parentField($this->_config['parent']['module']);
+        if (isset($this->_config['parent'])) {
+            $this->parentSection($this->_config['parent']);
         }
 
         // set virtual field(s)
@@ -163,6 +175,53 @@ trait ConfigurationTrait
         }
 
         return $this->_lookupFields;
+    }
+
+    /**
+     * parse 'parent' section variables
+     * @TODO: Currently we use only scalars for parent vars
+     * It should be expanded to support arrays if any appear.
+     * @param array $section containing 'parent' block from ini
+     * @return void
+     */
+    public function parentSection($section = [])
+    {
+        if (!empty($section)) {
+            foreach ($section as $fieldName => $fieldValues) {
+                $field = Inflector::camelize($fieldName);
+                $property = sprintf('_parent%sField', $field);
+                if (property_exists($this, $property)) {
+                    $this->{$property} = $fieldValues;
+                }
+            }
+        }
+    }
+
+    /**
+     * getParentRelationField
+     * @return string
+     */
+    public function getParentModuleField()
+    {
+        return $this->_parentModuleField;
+    }
+
+    /**
+     * getParentRedirectField
+     * @return string
+     */
+    public function getParentRedirectField()
+    {
+        return $this->_parentRedirectField;
+    }
+
+    /**
+     * getParentRelationField
+     * @return string
+     */
+    public function getParentRelationField()
+    {
+        return $this->_parentRelationField;
     }
 
     /**
@@ -228,23 +287,6 @@ trait ConfigurationTrait
         }
 
         return $this->_moduleAlias;
-    }
-
-
-    /**
-     * CSV Table might have a parent
-     * that helps us redirect things on working
-     * with modal forms.
-     * @param string $field received
-     * @return string
-     */
-    public function parentField($field = null)
-    {
-        if ($field !== null) {
-            $this->_parentField = $field;
-        }
-
-        return $this->_parentField;
     }
 
     /**

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -30,6 +30,13 @@ trait ConfigurationTrait
     protected $_lookupFields;
 
     /**
+     * Each table might have a parent
+     * @var string
+     */
+    protected $_parentField;
+
+
+    /**
      * Typeahead fields used for searching in related fields
      *
      * @var array
@@ -42,6 +49,19 @@ trait ConfigurationTrait
      * @var array
      */
     protected $_virtualFields = [];
+
+    /**
+     * Hidden associations
+     * @var array
+     */
+    protected $_hiddenAssociations = [];
+
+
+    /**
+     * Association Labels
+     * @var array
+     */
+    protected $_associationLabels = [];
 
     /**
      * Module alias
@@ -98,6 +118,18 @@ trait ConfigurationTrait
             $this->isSearchable($this->_config['table']['searchable']);
         }
 
+        if (isset($this->_config['associations']['hide_associations'])) {
+            $this->hiddenAssociations($this->_config['associations']['hide_associations']);
+        }
+
+        if (isset($this->_config['associations']['association_labels'])) {
+            $this->associationLabels($this->_config['associations']['association_labels']);
+        }
+
+        if (isset($this->_config['parent']['module'])) {
+            $this->parentField($this->_config['parent']['module']);
+        }
+
         // set virtual field(s)
         if (isset($this->_config['virtualFields'])) {
             $this->setVirtualFields($this->_config['virtualFields']);
@@ -150,6 +182,37 @@ trait ConfigurationTrait
     }
 
     /**
+     * Return association labels if any present
+     * @param array $fields
+     * @return array
+     */
+    public function associationLabels($fields = null)
+    {
+        if ($fields !== null) {
+            foreach($fields as $field) {
+                list($associationName, $associationLabel) = explode(',', $field);
+                $this->_associationLabels[$associationName] = $associationLabel;
+            }
+        }
+
+        return $this->_associationLabels;
+    }
+
+    /**
+     * Return the list of hidden Associations for the config
+     * file
+     * @param string|null $fields
+     * @return array
+     */
+    public function hiddenAssociations($fields = null)
+    {
+        if ($fields !== null) {
+            $this->_hiddenAssociations = explode(',', $fields);
+        }
+        return $this->_hiddenAssociations;
+    }
+
+    /**
      * Returns the module alias or sets a new one
      *
      * @param  string|null $alias sets a new name to be used as module alias
@@ -166,6 +229,23 @@ trait ConfigurationTrait
         }
 
         return $this->_moduleAlias;
+    }
+
+
+    /**
+    * CSV Table might have a parent
+    * that helps us redirect things on working
+    * with modal forms.
+    * @param string $field
+    * @return string
+    */
+    public function parentField($field = null)
+    {
+        if ($field !== null) {
+            $this->_parentField = $field;
+        }
+
+        return $this->_parentField;
     }
 
     /**

--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -75,7 +75,6 @@ class CsvViewComponent extends Component
         $this->_setTableInstance($this->_controllerInstance->request->params);
 
         if (in_array($this->request->params['action'], $this->_assocActions)) {
-
             $ev = new Event('CsvMigrations.View.View.Tabs', $this, [[
                 'controllerInstance' => $event->subject(),
                 'tableInstance' => $this->_tableInstance,

--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -6,6 +6,7 @@ use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\ORM\Association;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
@@ -23,11 +24,6 @@ use \RuntimeException;
 class CsvViewComponent extends Component
 {
     use PanelUtilTrait;
-
-    /**
-     * Associated fields action name.
-     */
-    const ASSOC_FIELDS_ACTION = 'index';
 
     /**
      * Default configuration.
@@ -79,8 +75,17 @@ class CsvViewComponent extends Component
         $this->_setTableInstance($this->_controllerInstance->request->params);
 
         if (in_array($this->request->params['action'], $this->_assocActions)) {
-            // associated records
-            $this->_controllerInstance->set('csvAssociatedRecords', $this->_setAssociatedRecords());
+
+            $ev = new Event('CsvMigrations.View.View.Tabs', $this, [[
+                'controllerInstance' => $event->subject(),
+                'tableInstance' => $this->_tableInstance,
+                'assocTypes' => $this->_assocTypes
+            ]]);
+
+            EventManager::instance()->dispatch($ev);
+            $this->_controllerInstance->set('csvAssociatedRecords', $ev->result['csvAssociatedRecords']);
+            $this->_controllerInstance->set('csvAssociationLabels', $ev->result['csvAssociationLabels']);
+
             $this->_controllerInstance->set('_serialize', ['csvAssociatedRecords']);
         }
 
@@ -132,245 +137,6 @@ class CsvViewComponent extends Component
         $this->_tableInstance = TableRegistry::get($table);
 
         return $this->_tableInstance;
-    }
-
-    /**
-     * Method that retrieves specified Table's
-     * associated records and passes them to the View.
-     *
-     * @return array
-     */
-    protected function _setAssociatedRecords()
-    {
-        $result = [];
-        // loop through associations
-        foreach ($this->_tableInstance->associations() as $association) {
-            $assocType = $association->type();
-            if (in_array($assocType, $this->_assocTypes)) {
-                // get associated records
-                switch ($assocType) {
-                    case 'manyToOne':
-                        $associatedRecords = $this->_manyToOneAssociatedRecords($association);
-                        if (!empty($associatedRecords)) {
-                            $result[$assocType][$association->foreignKey()] = $associatedRecords;
-                        }
-                        break;
-
-                    case 'oneToMany':
-                        $associatedRecords = $this->_oneToManyAssociatedRecords($association);
-                        if (!empty($associatedRecords)) {
-                            $result[$assocType][$association->name()] = $associatedRecords;
-                        }
-                        break;
-
-                    case 'manyToMany':
-                        $result[$assocType][$association->name()] = $this->_manyToManyAssociatedRecords(
-                            $association
-                        );
-                        break;
-                }
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * Method that retrieves many to one associated records.
-     *
-     * @param  \Cake\ORM\Association $association Association object
-     * @return array                              associated records
-     */
-    protected function _manyToOneAssociatedRecords(Association $association)
-    {
-        $result = [];
-        $tableName = $this->_tableInstance->table();
-        $primaryKey = $this->_tableInstance->primaryKey();
-        $assocTableName = $association->table();
-        $assocPrimaryKey = $association->primaryKey();
-        $assocForeignKey = $association->foreignKey();
-        $recordId = $this->request->params['pass'][0];
-        $displayField = $association->displayField();
-
-        /*
-         * skip inverse relationship
-         *
-         * @todo find better way to handle it
-         */
-        if ($tableName === $assocTableName) {
-            return $result;
-        }
-
-        $connection = ConnectionManager::get('default');
-        // NOTE: This will break if $assocTableName has no primary key or has a combined primary key
-        $records = $connection
-            ->execute(
-                'SELECT ' . $assocTableName . '.' . $assocPrimaryKey . ' FROM ' . $tableName . ' LEFT JOIN ' . $assocTableName . ' ON ' . $tableName . '.' . $assocForeignKey . ' = ' . $assocTableName . '.' . $assocPrimaryKey . ' WHERE ' . $tableName . '.' . $primaryKey . ' = :id LIMIT 1',
-                ['id' => $recordId]
-            )
-            ->fetchAll('assoc');
-
-        // store associated table records, make sure associated record still exists.
-        if (!empty($records[0][$assocPrimaryKey]) &&
-            $association->exists([$assocPrimaryKey => $records[0][$assocPrimaryKey]])
-        ) {
-            $result = $association->get($records[0][$assocPrimaryKey])->{$displayField};
-        } else {
-            $result = null;
-        }
-
-        return $result;
-    }
-
-    /**
-     * Method that retrieves one to many associated records
-     *
-     * @param  \Cake\ORM\Association $association Association object
-     * @return array                              associated records
-     */
-    protected function _oneToManyAssociatedRecords(Association $association)
-    {
-        $result = [];
-        $assocName = $association->name();
-        $assocTableName = $association->table();
-        $assocForeignKey = $association->foreignKey();
-        $recordId = $this->request->params['pass'][0];
-
-        $csvFields = $this->_getAssociationCsvFields($association, static::ASSOC_FIELDS_ACTION);
-        if (empty($csvFields)) {
-            return $result;
-        }
-
-        // get associated index View csv fields
-        $fields = array_unique(
-            array_merge(
-                [$association->displayField()],
-                $csvFields
-            )
-        );
-
-        $query = $this->_tableInstance->{$assocName}->find('all', [
-            'conditions' => [$assocForeignKey => $recordId]
-        ]);
-        $records = $query->all();
-        // store association name
-        $result['assoc_name'] = $assocName;
-        // store associated table name
-        $result['table_name'] = $assocTableName;
-        // store associated table class name
-        $result['class_name'] = $association->className();
-        // store associated table display field
-        $result['display_field'] = $association->displayField();
-        // store associated table primary key
-        $result['primary_key'] = $association->primaryKey();
-        // store associated table foreign key
-        $result['foreign_key'] = $association->foreignKey();
-        // store associated table fields
-        $result['fields'] = $fields;
-        // store associated table records
-        $result['records'] = $records;
-
-        return $result;
-    }
-
-    /**
-     * Method that retrieves many to many associated records
-     *
-     * @param  \Cake\ORM\Association $association Association object
-     * @return array                              associated records
-     * @todo  find better way to fetch associated data, without including current table's data
-     */
-    protected function _manyToManyAssociatedRecords(Association $association)
-    {
-        $result = [];
-        $assocName = $association->name();
-        $assocTableName = $association->table();
-        $assocForeignKey = $association->foreignKey();
-
-        $csvFields = $this->_getAssociationCsvFields($association, static::ASSOC_FIELDS_ACTION);
-        if (empty($csvFields)) {
-            return $result;
-        }
-        // get associated index View csv fields
-        $fields = array_unique(
-            array_merge(
-                [$association->displayField()],
-                $csvFields
-            )
-        );
-        $query = $this->_tableInstance->find('all', [
-            'conditions' => [$this->_tableInstance->primaryKey() => $this->request->params['pass'][0]],
-            'contain' => [
-                $assocName
-            ]
-        ]);
-        $records = $query->first()->{$assocTableName};
-        // store association name
-        $result['assoc_name'] = $assocName;
-        // store associated table name
-        $result['table_name'] = $assocTableName;
-        // store associated table class name
-        $result['class_name'] = $association->className();
-        // store associated table display field
-        $result['display_field'] = $association->displayField();
-        // store associated table primary key
-        $result['primary_key'] = $association->primaryKey();
-        // store associated table foreign key
-        $result['foreign_key'] = Inflector::singularize($assocTableName) . '_' . $association->primaryKey();
-        // store associated table fields
-        $result['fields'] = $fields;
-        // store associated table records
-        $result['records'] = $records;
-
-        return $result;
-    }
-
-    /**
-     * Method that retrieves associated table csv fields, by specified action.
-     *
-     * @param  \Cake\ORM\Association $association Association
-     * @param  string                $action      Action name
-     * @return array                              table fields
-     */
-    protected function _getAssociationCsvFields(Association $association, $action)
-    {
-        list($plugin, $controller) = pluginSplit($association->className());
-
-        return $this->_getCsvFields($controller, $action);
-    }
-
-    /**
-     * Method that retrieves table csv fields, by specified action.
-     *
-     * @param  string $tableName Table name
-     * @param  string $action    Action name
-     * @return array             table fields
-     */
-    protected function _getCsvFields($tableName, $action)
-    {
-        $result = [];
-
-        if (empty($tableName) || empty($action)) {
-            return $result;
-        }
-
-        try {
-            $pathFinder = new ViewPathFinder;
-            $path = $pathFinder->find($tableName, $action);
-            $csvFields = $this->_getFieldsFromCsv($path);
-        } catch (Exception $e) {
-            return $result;
-        }
-
-        if (empty($csvFields)) {
-            return $result;
-        }
-
-        $result = array_map(function ($v) {
-            return $v[0];
-        }, $csvFields);
-
-        return $result;
     }
 
     /**

--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -53,7 +53,9 @@ class ViewViewTabsListener implements EventListenerInterface
             $tableConfig = $this->_tableInstance->getConfig();
 
             $hiddenAssociations = $this->_tableInstance->hiddenAssociations();
-            $csvAssociationLabels = $this->_tableInstance->associationLabels($tableConfig['associationLabels']);
+            if (!empty($tableConfig['associationLabels'])) {
+                $csvAssociationLabels = $this->_tableInstance->associationLabels($tableConfig['associationLabels']);
+            }
         }
 
         foreach ($this->_tableInstance->associations() as $association) {

--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -53,7 +53,7 @@ class ViewViewTabsListener implements EventListenerInterface
             $tableConfig = $this->_tableInstance->getConfig();
 
             $hiddenAssociations = $this->_tableInstance->hiddenAssociations();
-            $csvAssociationLabels = $this->_tableInstance->associationLabels();
+            $csvAssociationLabels = $this->_tableInstance->associationLabels($tableConfig['associationLabels']);
         }
 
         foreach ($this->_tableInstance->associations() as $association) {

--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -1,0 +1,303 @@
+<?php
+namespace CsvMigrations\Events;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\ORM\Association;
+use Cake\Utility\Inflector;
+use CsvMigrations\MigrationTrait;
+use CsvMigrations\Panel;
+use CsvMigrations\PanelUtilTrait;
+use CsvMigrations\Parser\Csv\ViewParser;
+use CsvMigrations\PathFinder\ViewPathFinder;
+
+class ViewViewTabsListener implements EventListenerInterface
+{
+    use MigrationTrait;
+
+	const ASSOC_FIELDS_ACTION = 'index';
+
+	protected $_tableInstance;
+	protected $_controllerInstance;
+    protected $_assocTypes;
+
+    /**
+     * Implemented Events
+     * @return array
+     */
+    public function implementedEvents()
+    {
+        return [
+            'CsvMigrations.View.View.Tabs' => 'getViewTabs'
+        ];
+    }
+
+    /**
+     * getViewViewTabs method
+     *
+     * @param Cake\Event\Event $event used for getting reports
+     * @param ArrayObject $options for params
+     * @return array $data with all .ini reports
+     */
+    public function getViewTabs(Event $event, array $instances)
+    {
+        $this->_controllerInstance = $instances['controllerInstance'];
+        $this->_tableInstance = $instances['tableInstance'];
+        $this->_assocTypes = $instances['assocTypes'];
+		$hiddenAssociations = [];
+		$csvAssociationLabels = [];
+	  	$csvAssociatedRecords = [];
+
+        if (method_exists($this->_tableInstance, 'getConfig')) {
+            $tableConfig = $this->_tableInstance->getConfig();
+
+            $hiddenAssociations = $this->_tableInstance->hiddenAssociations();
+            $csvAssociationLabels = $this->_tableInstance->associationLabels();
+        }
+
+        foreach ($this->_tableInstance->associations() as $association) {
+            if (in_array($association->name(), $hiddenAssociations)) {
+                continue;
+            }
+
+            $assocType = $association->type();
+            if (in_array($assocType, $this->_assocTypes)) {
+                // get associated records
+                switch ($assocType) {
+                    case 'manyToOne':
+                        $associatedRecords = $this->_manyToOneAssociatedRecords($association);
+                        if (!empty($associatedRecords)) {
+                            $csvAssociatedRecords[$assocType][$association->foreignKey()] = $associatedRecords;
+                        }
+                        break;
+
+                    case 'oneToMany':
+                        $associatedRecords = $this->_oneToManyAssociatedRecords($association);
+                        if (!empty($associatedRecords)) {
+                            $csvAssociatedRecords[$assocType][$association->name()] = $associatedRecords;
+                        }
+                        break;
+
+                    case 'manyToMany':
+                        $csvAssociatedRecords[$assocType][$association->name()] = $this->_manyToManyAssociatedRecords(
+                            $association
+                        );
+                        break;
+                }
+            }
+        }
+
+        return compact('csvAssociatedRecords', 'csvAssociationLabels');
+    }
+
+
+   	/**
+     * Method that retrieves many to many associated records
+     *
+     * @param  \Cake\ORM\Association $association Association object
+     * @return array                              associated records
+     * @todo  find better way to fetch associated data, without including current table's data
+     */
+    protected function _manyToManyAssociatedRecords(Association $association)
+    {
+        $result = [];
+        $assocName = $association->name();
+        $assocTableName = $association->table();
+        $assocForeignKey = $association->foreignKey();
+
+        $csvFields = $this->_getAssociationCsvFields($association, static::ASSOC_FIELDS_ACTION);
+        if (empty($csvFields)) {
+            return $result;
+        }
+        // get associated index View csv fields
+        $fields = array_unique(
+            array_merge(
+                [$association->displayField()],
+                $csvFields
+            )
+        );
+        $query = $this->_tableInstance->find('all', [
+            'conditions' => [$this->_tableInstance->primaryKey() => $this->_controllerInstance->request->params['pass'][0]],
+            'contain' => [
+                $assocName
+            ]
+        ]);
+        $records = $query->first()->{$assocTableName};
+        // store association name
+        $result['assoc_name'] = $assocName;
+        // store associated table name
+        $result['table_name'] = $assocTableName;
+        // store associated table class name
+        $result['class_name'] = $association->className();
+        // store associated table display field
+        $result['display_field'] = $association->displayField();
+        // store associated table primary key
+        $result['primary_key'] = $association->primaryKey();
+        // store associated table foreign key
+        $result['foreign_key'] = Inflector::singularize($assocTableName) . '_' . $association->primaryKey();
+        // store associated table fields
+        $result['fields'] = $fields;
+        // store associated table records
+        $result['records'] = $records;
+
+        return $result;
+    }
+
+	/**
+     * Method that retrieves many to one associated records.
+     *
+     * @param  \Cake\ORM\Association $association Association object
+     * @return array                              associated records
+     */
+    protected function _manyToOneAssociatedRecords(Association $association)
+    {
+        $result = [];
+        $tableName = $this->_tableInstance->table();
+        $primaryKey = $this->_tableInstance->primaryKey();
+        $assocTableName = $association->table();
+        $assocPrimaryKey = $association->primaryKey();
+        $assocForeignKey = $association->foreignKey();
+        $recordId = $this->_controllerInstance->request->params['pass'][0];
+        $displayField = $association->displayField();
+
+        /*
+         * skip inverse relationship
+         *
+         * @todo find better way to handle it
+         */
+        if ($tableName === $assocTableName) {
+            return $result;
+        }
+
+        $connection = ConnectionManager::get('default');
+        // NOTE: This will break if $assocTableName has no primary key or has a combined primary key
+        $records = $connection
+            ->execute(
+                'SELECT ' . $assocTableName . '.' . $assocPrimaryKey . ' FROM ' . $tableName . ' LEFT JOIN ' . $assocTableName . ' ON ' . $tableName . '.' . $assocForeignKey . ' = ' . $assocTableName . '.' . $assocPrimaryKey . ' WHERE ' . $tableName . '.' . $primaryKey . ' = :id LIMIT 1',
+                ['id' => $recordId]
+            )
+            ->fetchAll('assoc');
+
+        // store associated table records, make sure associated record still exists.
+        if (!empty($records[0][$assocPrimaryKey]) &&
+            $association->exists([$assocPrimaryKey => $records[0][$assocPrimaryKey]])
+        ) {
+            $result = $association->get($records[0][$assocPrimaryKey])->{$displayField};
+        } else {
+            $result = null;
+        }
+
+        return $result;
+    }
+
+	/**
+     * Method that retrieves one to many associated records
+     *
+     * @param  \Cake\ORM\Association $association Association object
+     * @return array                              associated records
+     */
+    protected function _oneToManyAssociatedRecords(Association $association)
+    {
+        $result = [];
+        $assocName = $association->name();
+        $assocTableName = $association->table();
+        $assocForeignKey = $association->foreignKey();
+        $recordId = $this->_controllerInstance->request->params['pass'][0];
+
+        $csvFields = $this->_getAssociationCsvFields($association, static::ASSOC_FIELDS_ACTION);
+        if (empty($csvFields)) {
+            return $result;
+        }
+
+        // get associated index View csv fields
+        $fields = array_unique(
+            array_merge(
+                [$association->displayField()],
+                $csvFields
+            )
+        );
+
+        $query = $this->_tableInstance->{$assocName}->find('all', [
+            'conditions' => [$assocForeignKey => $recordId]
+        ]);
+        $records = $query->all();
+        // store association name
+        $result['assoc_name'] = $assocName;
+        // store associated table name
+        $result['table_name'] = $assocTableName;
+        // store associated table class name
+        $result['class_name'] = $association->className();
+        // store associated table display field
+        $result['display_field'] = $association->displayField();
+        // store associated table primary key
+        $result['primary_key'] = $association->primaryKey();
+        // store associated table foreign key
+        $result['foreign_key'] = $association->foreignKey();
+        // store associated table fields
+        $result['fields'] = $fields;
+        // store associated table records
+        $result['records'] = $records;
+
+        return $result;
+    }
+
+   	protected function _getAssociationCsvFields(Association $association, $action)
+    {
+        list($plugin, $controller) = pluginSplit($association->className());
+
+        return $this->_getCsvFields($controller, $action);
+    }
+
+	 /**
+     * Method that retrieves table csv fields, by specified action.
+     *
+     * @param  string $tableName Table name
+     * @param  string $action    Action name
+     * @return array             table fields
+     */
+    protected function _getCsvFields($tableName, $action)
+    {
+        $result = [];
+
+        if (empty($tableName) || empty($action)) {
+            return $result;
+        }
+
+        try {
+            $pathFinder = new ViewPathFinder;
+            $path = $pathFinder->find($tableName, $action);
+            $csvFields = $this->_getFieldsFromCsv($path);
+        } catch (Exception $e) {
+            return $result;
+        }
+
+        if (empty($csvFields)) {
+            return $result;
+        }
+
+        $result = array_map(function ($v) {
+            return $v[0];
+        }, $csvFields);
+
+        return $result;
+    }
+
+	 /**
+     * Method that gets fields from a csv file
+     *
+     * @param  string $path   csv file path
+     * @return array          csv data
+     */
+    protected function _getFieldsFromCsv($path)
+    {
+        $result = [];
+        if (is_readable($path)) {
+            $parser = new ViewParser();
+            $result = $parser->parseFromPath($path);
+        }
+
+        return $result;
+    }
+
+}

--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -16,10 +16,10 @@ class ViewViewTabsListener implements EventListenerInterface
 {
     use MigrationTrait;
 
-	const ASSOC_FIELDS_ACTION = 'index';
+    const ASSOC_FIELDS_ACTION = 'index';
 
-	protected $_tableInstance;
-	protected $_controllerInstance;
+    protected $_tableInstance;
+    protected $_controllerInstance;
     protected $_assocTypes;
 
     /**
@@ -45,9 +45,9 @@ class ViewViewTabsListener implements EventListenerInterface
         $this->_controllerInstance = $instances['controllerInstance'];
         $this->_tableInstance = $instances['tableInstance'];
         $this->_assocTypes = $instances['assocTypes'];
-		$hiddenAssociations = [];
-		$csvAssociationLabels = [];
-	  	$csvAssociatedRecords = [];
+        $hiddenAssociations = [];
+        $csvAssociationLabels = [];
+        $csvAssociatedRecords = [];
 
         if (method_exists($this->_tableInstance, 'getConfig')) {
             $tableConfig = $this->_tableInstance->getConfig();
@@ -92,7 +92,7 @@ class ViewViewTabsListener implements EventListenerInterface
     }
 
 
-   	/**
+    /**
      * Method that retrieves many to many associated records
      *
      * @param  \Cake\ORM\Association $association Association object
@@ -144,7 +144,7 @@ class ViewViewTabsListener implements EventListenerInterface
         return $result;
     }
 
-	/**
+    /**
      * Method that retrieves many to one associated records.
      *
      * @param  \Cake\ORM\Association $association Association object
@@ -191,7 +191,7 @@ class ViewViewTabsListener implements EventListenerInterface
         return $result;
     }
 
-	/**
+    /**
      * Method that retrieves one to many associated records
      *
      * @param  \Cake\ORM\Association $association Association object
@@ -242,14 +242,20 @@ class ViewViewTabsListener implements EventListenerInterface
         return $result;
     }
 
-   	protected function _getAssociationCsvFields(Association $association, $action)
+    /**
+     * Get association CSV fields
+     * @param Cake\ORM\Associations $association ORM association
+     * @param object $action action passed
+     * @return array
+     */
+    protected function _getAssociationCsvFields(Association $association, $action)
     {
         list($plugin, $controller) = pluginSplit($association->className());
 
         return $this->_getCsvFields($controller, $action);
     }
 
-	 /**
+    /**
      * Method that retrieves table csv fields, by specified action.
      *
      * @param  string $tableName Table name
@@ -283,7 +289,7 @@ class ViewViewTabsListener implements EventListenerInterface
         return $result;
     }
 
-	 /**
+    /**
      * Method that gets fields from a csv file
      *
      * @param  string $path   csv file path
@@ -299,5 +305,4 @@ class ViewViewTabsListener implements EventListenerInterface
 
         return $result;
     }
-
 }

--- a/src/Template/Element/associated_records.ctp
+++ b/src/Template/Element/associated_records.ctp
@@ -4,7 +4,6 @@ use Cake\Utility\Inflector;
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;
 
 $fhf = new FieldHandlerFactory();
-
 $panels = [];
 if (!empty($csvAssociatedRecords['oneToMany'])) {
     foreach ($csvAssociatedRecords['oneToMany'] as $tabName => $assocData) {
@@ -15,7 +14,6 @@ if (!empty($csvAssociatedRecords['oneToMany'])) {
         }
     }
 }
-
 /*
 list of embedded fields to generate modals from
  */
@@ -30,7 +28,6 @@ if (!empty($csvAssociatedRecords['manyToMany'])) {
     }
 }
 ?>
-
 <?php if (!empty($panels)) : ?>
 <div class="row associated_records">
     <div class="col-xs-12">
@@ -43,13 +40,18 @@ if (!empty($csvAssociatedRecords['manyToMany'])) {
             <li role="presentation" class="<?= $active; ?>">
                 <a href="#<?= $tabName; ?>" aria-controls="<?= $tabName; ?>" role="tab" data-toggle="tab">
                     <?php
-                        $tableName = Inflector::humanize($assocData['table_name']);
-                        $fieldName = trim(str_replace($tableName, '', Inflector::humanize(Inflector::tableize($tabName))));
-                        if (!empty($fieldName)) {
-                            $fieldName = ' <small>(' . $fieldName . ')</small>';
+                        //prettifying the tabs names
+                        if (!empty($csvAssociationLabels) && in_array($tabName, array_keys($csvAssociationLabels))) {
+                            echo $csvAssociationLabels[$tabName];
+                        } else {
+                            $tableName = Inflector::humanize($assocData['table_name']);
+                            $fieldName = trim(str_replace($tableName, '', Inflector::humanize(Inflector::tableize($tabName))));
+                            if (!empty($fieldName)) {
+                                $fieldName = '<small>(' . $fieldName . ')</small>';
+                            }
+                            echo $tableName . $fieldName;
                         }
                     ?>
-                    <?= $tableName . $fieldName ?>
                 </a>
             </li>
 <?php
@@ -61,7 +63,7 @@ if (!empty($csvAssociatedRecords['manyToMany'])) {
 <?php
     $active = 'active';
     foreach ($panels as $assocName => $assocData) {
-    ?>
+?>
             <div role="tabpanel" class="tab-pane <?= $active; ?>" id="<?= $assocName; ?>">
             <?php
             /*

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -28,4 +28,89 @@ class ConfigurationTraitTest extends PHPUnit_Framework_TestCase
         $this->assertSame($this->mock->moduleAlias('foo'), 'foo');
         $this->assertSame($this->mock->moduleAlias(), 'foo');
     }
+
+    public function testHiddenAssociations()
+    {
+        $this->assertSame($this->mock->hiddenAssociations('Foo,Bar'), ['Foo', 'Bar']);
+    }
+
+    public function testAssociationLabels()
+    {
+        $this->assertSame(
+            $this->mock->associationLabels(['Foo,Foo Bar', 'Bar,Baz']),
+            ['Foo' => 'Foo Bar', 'Bar' => 'Baz'],
+            "Association Labels are parsed incorrectly"
+        );
+    }
+
+    public function testAssociationLabelsSpecialSymbols()
+    {
+        $this->assertSame(
+            $this->mock->associationLabels(["Foo,Foo Bar()"]),
+            ['Foo' => 'Foo Bar()'],
+            "Special symbols cannot be parsed properly"
+        );
+    }
+
+    public function testParentField()
+    {
+        $this->assertSame(
+            $this->mock->parentField('Bar'),
+            'Bar',
+            "Parent field is not passed properly into setter"
+        );
+    }
+
+    public function testLookupFields()
+    {
+        $this->assertSame(
+            $this->mock->lookupFields(),
+            null,
+            "Default lookupField is not set yet"
+        );
+
+        $this->assertSame(
+            $this->mock->lookupFields('foo,bar'),
+            ['foo', 'bar'],
+            "Incorrect setting of lookUp fields"
+        );
+    }
+
+    public function testVirtualFields()
+    {
+        $this->assertEquals(
+            $this->mock->setVirtualFields(),
+            null,
+            "Incorrect default value"
+        );
+
+        $data = [
+            'virtualFields' => [
+                'name' => 'company_name,first_name,last_name'
+            ]
+        ];
+
+        $this->mock->setVirtualFields($data['virtualFields']);
+
+        $this->assertSame(
+            $this->mock->getVirtualFields(),
+            ['name' => ['company_name', 'first_name', 'last_name']],
+            'Incorrect Virtual Fields setting'
+        );
+    }
+
+    public function testTypeaheadFields()
+    {
+        $this->assertSame(
+            $this->mock->typeaheadFields(),
+            null,
+            "Incorrect default value"
+        );
+
+        $this->assertSame(
+            $this->mock->typeaheadFields('first_name,last_name'),
+            ['first_name', 'last_name'],
+            "Incorrect values passed"
+        );
+    }
 }

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -49,6 +49,24 @@ class ConfigurationTraitTest extends PHPUnit_Framework_TestCase
         );
     }
 
+
+    public function testParentSection()
+    {
+        $data = [
+            'parent' => [
+                'module' => 'Companies',
+                'relation' => 'company_id',
+                'redirect' => 'self'
+            ]
+        ];
+
+        $this->mock->parentSection($data['parent']);
+
+        $this->assertEquals('Companies', $this->mock->getParentModuleField());
+        $this->assertEquals('company_id', $this->mock->getParentRelationField());
+        $this->assertEquals('self', $this->mock->getParentRedirectField());
+    }
+
     public function testAssociationLabelsSpecialSymbols()
     {
         $data = ['associationLabels' => [ 'EntityIdTable' => "Super Uper ()"]];
@@ -57,15 +75,6 @@ class ConfigurationTraitTest extends PHPUnit_Framework_TestCase
             $this->mock->associationLabels($data['associationLabels']),
             ['EntityIdTable' => 'Super Uper ()'],
             "Special symbols cannot be parsed properly"
-        );
-    }
-
-    public function testParentField()
-    {
-        $this->assertSame(
-            $this->mock->parentField('Bar'),
-            'Bar',
-            "Parent field is not passed properly into setter"
         );
     }
 

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -36,18 +36,26 @@ class ConfigurationTraitTest extends PHPUnit_Framework_TestCase
 
     public function testAssociationLabels()
     {
+        $data = [
+            'associationLabels' => [
+                'Foo' => 'Bar'
+            ]
+        ];
+
         $this->assertSame(
-            $this->mock->associationLabels(['Foo,Foo Bar', 'Bar,Baz']),
-            ['Foo' => 'Foo Bar', 'Bar' => 'Baz'],
+            $this->mock->associationLabels($data['associationLabels']),
+            ['Foo' => 'Bar'],
             "Association Labels are parsed incorrectly"
         );
     }
 
     public function testAssociationLabelsSpecialSymbols()
     {
+        $data = ['associationLabels' => [ 'EntityIdTable' => "Super Uper ()"]];
+
         $this->assertSame(
-            $this->mock->associationLabels(["Foo,Foo Bar()"]),
-            ['Foo' => 'Foo Bar()'],
+            $this->mock->associationLabels($data['associationLabels']),
+            ['EntityIdTable' => 'Super Uper ()'],
             "Special symbols cannot be parsed properly"
         );
     }

--- a/tests/TestCase/Model/Table/FooTableTest.php
+++ b/tests/TestCase/Model/Table/FooTableTest.php
@@ -98,10 +98,11 @@ class FooTableTest extends TestCase
                 ],
                 'associations' => [
                     'hide_associations' => 'TestTable',
-                    'association_labels' => [
-                        'FieldIdTable,Table',
-                        'AnotherIdTableTwo,Pretty Table'
-                    ]
+                ],
+
+                'associationLabels' => [
+                    'FieldIdTable' => 'Table',
+                    'AnotherIdTableTwo' => 'Pretty Table'
                 ]
             ]
         );

--- a/tests/TestCase/Model/Table/FooTableTest.php
+++ b/tests/TestCase/Model/Table/FooTableTest.php
@@ -84,7 +84,24 @@ class FooTableTest extends TestCase
                 'table' => [
                     'alias' => 'Foobar',
                     'searchable' => true,
-                    'display_field' => 'name'
+                    'display_field' => 'name',
+                    'typeahead_fields' => 'name,foobar',
+                    'lookup_fields' => 'foo,bar,baz',
+                ],
+                'virtualFields' => [
+                    'name' => 'full_name',
+                ],
+                'parent' => [
+                    'module' => 'TestModule',
+                    'redirect' => 'self',
+
+                ],
+                'associations' => [
+                    'hide_associations' => 'TestTable',
+                    'association_labels' => [
+                        'FieldIdTable,Table',
+                        'AnotherIdTableTwo,Pretty Table'
+                    ]
                 ]
             ]
         );

--- a/tests/TestCase/Parser/Ini/ParserTest.php
+++ b/tests/TestCase/Parser/Ini/ParserTest.php
@@ -28,4 +28,16 @@ class ParserTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(empty($result['table']['display_field']), "Parser missed 'display_field' key");
         $this->assertEquals('name', $result['table']['display_field'], "Parser misinterpreted 'display_field' value");
     }
+
+    public function testParseFromPathTestingArrays()
+    {
+        $file = dirname(dirname(dirname(__DIR__))) . DS . 'data' . DS . 'CsvMigrations' . DS . 'migrations' . DS . 'Foo' . DS . 'array_in_config.ini';
+        $parser = new Parser();
+        $result = $parser->parseFromPath($file);
+
+        $this->assertTrue(is_array($result), 'Return data from parser isn\'t array type');
+        $this->assertArrayHasKey('associations', $result, "No associations found in the table config");
+        $this->assertArrayHasKey('association_labels', $result['associations'], "No associations found in the table config");
+        $this->assertTrue(is_array($result['associations']['association_labels']), "Associations label is not an array");
+    }
 }

--- a/tests/data/CsvMigrations/migrations/Foo/array_in_config.ini
+++ b/tests/data/CsvMigrations/migrations/Foo/array_in_config.ini
@@ -1,0 +1,11 @@
+[table]
+alias = Foobar
+searchable = true
+display_field = name
+
+[associations]
+; Associations might be generated based
+; on registryAlias, that's not really
+; readable.
+association_labels[] = BarIdBaz,'Baz'
+association_labels[] = FieldIdTableName,'Table Name'

--- a/tests/data/CsvMigrations/migrations/Foo/config.ini
+++ b/tests/data/CsvMigrations/migrations/Foo/config.ini
@@ -13,5 +13,7 @@ redirect = self
 
 [associations]
 hide_associations = TestTable
-association_labels[] = FieldIdTable,Table
-association_labels[] = AnotherIdTableTwo,Pretty Table
+
+[associationLabels]
+FieldIdTable = Table
+AnotherIdTableTwo = "Pretty Table"

--- a/tests/data/CsvMigrations/migrations/Foo/config.ini
+++ b/tests/data/CsvMigrations/migrations/Foo/config.ini
@@ -2,3 +2,17 @@
 alias = Foobar
 searchable = true
 display_field = name
+typeahead_fields = name,foobar
+lookup_fields = foo,bar,baz
+[virtualFields]
+name = full_name
+
+[parent]
+module = TestModule
+redirect = self
+
+[associations]
+hide_associations = TestTable
+
+association_labels[] = FieldIdTable,Table
+association_labels[] = AnotherIdTableTwo,Pretty Table

--- a/tests/data/CsvMigrations/migrations/Foo/config.ini
+++ b/tests/data/CsvMigrations/migrations/Foo/config.ini
@@ -13,6 +13,5 @@ redirect = self
 
 [associations]
 hide_associations = TestTable
-
 association_labels[] = FieldIdTable,Table
 association_labels[] = AnotherIdTableTwo,Pretty Table


### PR DESCRIPTION
Decreased the size of the CsvViewComponent, to load most of the associations functionality into the Events for further refactoring and splitting it to other Events.

This pull request also introduces association labels, that let the user customize the tab names.

Example of associations panel:
```ini
[associations]
hide_associations = Foobar
association_labels[] = RelationIdFoobar,'Related Table 1'
association_labels[] = OtherFieldIdFoobar,'Managed Table 2'
```

