### PR TITLE
added basic cancel operation for add and edit forms (task #2992)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -80,6 +80,10 @@ class AppController extends BaseController
     {
         $entity = $this->{$this->name}->newEntity();
         if ($this->request->is('post')) {
+            if ($this->request->data('btn_operation') == 'cancel') {
+                return $this->redirect(['action' => 'index']);
+            }
+
             $entity = $this->{$this->name}->patchEntity($entity, $this->request->data);
             if ($this->{$this->name}->save($entity)) {
                 // handle file uploads if found in the request data
@@ -112,6 +116,9 @@ class AppController extends BaseController
             'contain' => []
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
+            if ($this->request->data('btn_operation') == 'cancel') {
+                return $this->redirect(['action' => 'view', $id]);
+            }
             /*
             enable accessibility to associated entity's primary key to avoid associated entity getting flagged as new
              */

--- a/src/Template/Element/View/add.ctp
+++ b/src/Template/Element/View/add.ctp
@@ -154,6 +154,12 @@ $formOptions['type'] = 'file';
          */
         if (!$this->request->param('pass.conversion')) {
             echo $this->Form->button(__('Submit'), ['class' => 'btn btn-primary']);
+
+            if (empty($this->request->query['embedded'])) {
+                echo "&nbsp;";
+                echo $this->Form->button(__('Cancel'), ['name' => 'btn_operation', 'value' => 'cancel', 'class' => 'btn btn-warning']);
+            }
+
             echo $this->Form->end();
         }
     ?>

--- a/src/Template/Element/View/edit.ctp
+++ b/src/Template/Element/View/edit.ctp
@@ -132,7 +132,12 @@ $formOptions['type'] = 'file';
                 }
             ?>
         </fieldset>
-        <?= $this->Form->button(__('Submit'), ['class' => 'btn btn-primary']) ?>
+        <?= $this->Form->button(__('Submit'), ['name' => 'btn_operation', 'value' => 'submit', 'class' => 'btn btn-primary']) ?>
+
+        <?php
+        if (empty($this->request->query['embedded'])) { ?>
+            <?= $this->Form->button(__('Cancel'), ['name' => 'btn_operation', 'value' => 'cancel', 'class' => 'btn btn-warning']) ?>
+        <?php } ?>
         <?= $this->Form->end() ?>
         <?php
         /*


### PR DESCRIPTION
We handle two types of forms - basic ones, and embedded. For basic forms, cancel button can work without any parents. `Parent section` of config file, would be used for embedded forms, when it's evident that we're in relations tab, operating within modal windows, and technically have a parent to which we redirect upon saving data.