### PR TITLE
Parent redirects (task #3006)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -100,7 +100,13 @@ class AppController extends BaseController
                 }
                 $this->Flash->success(__('The record has been saved.'));
 
-                return $this->redirect(['action' => 'view', $entity->{$this->{$this->name}->primaryKey()}]);
+                $redirectUrl = $this->{$this->name}->getParentRedirectUrl($this->{$this->name}, $entity);
+
+                if (empty($redirectUrl)) {
+                    return $this->redirect(['action' => 'view', $entity->{$this->{$this->name}->primaryKey()}]);
+                } else {
+                    return $this->redirect($redirectUrl);
+                }
             } else {
                 $this->Flash->error(__('The record could not be saved. Please, try again.'));
             }
@@ -139,7 +145,13 @@ class AppController extends BaseController
                 }
                 $this->Flash->success(__('The record has been saved.'));
 
-                return $this->redirect(['action' => 'view', $id]);
+                $redirectUrl = $this->{$this->name}->getParentRedirectUrl($this->{$this->name}, $entity);
+
+                if (empty($redirectUrl)) {
+                    return $this->redirect(['action' => 'view', $entity->{$this->{$this->name}->primaryKey()}]);
+                } else {
+                    return $this->redirect($redirectUrl);
+                }
             } else {
                 $this->Flash->error(__('The record could not be saved. Please, try again.'));
             }

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -500,6 +500,17 @@ class ValidateShell extends Shell
                         if (!in_array($config['parent']['redirect'], ['self', 'parent'])) {
                             $moduleErrors[] = $module . " config [parent] section references unknown redirect type '" . $config['parent']['redirect'] . "' in 'redirect key";
                         }
+
+                        //if redirect = parent, we force the user to mention the relation and module
+                        if (in_array($config['parent']['redirect'], ['parent'])) {
+                            if (empty($config['parent']['module'])) {
+                                $moduleErrors[] = $module . " config [parent] requires 'module' value when redirect = parent.";
+                            }
+
+                            if (empty($config['parent']['relation'])) {
+                                $moduleErrors[] = $module . " config [parent] requires 'relation' when redirect = parent.";
+                            }
+                        }
                     }
                 }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -95,6 +95,49 @@ class Table extends BaseTable
     }
 
     /**
+     * getParentRedirectUrl method
+     * Uses [parent] section of tables config.ini to define
+     * where to redirect after the entity was added/edited.
+     * @param Cake\ORM\Table $table of the entity table
+     * @param Cake\ORM\Entity $entity of the actual table.
+     *
+     * @return array $result containing Cake-standard array for redirect.
+     */
+    public function getParentRedirectUrl($table, $entity = [])
+    {
+        $result = [];
+
+        if (!method_exists($table, 'getConfig') && !is_callable([$table, 'getConfig'])) {
+            return $result;
+        }
+
+        $config = $table->getConfig();
+        $table->parentSection($config['parent']);
+
+        $module = $table->getParentModuleField();
+        $redirect = $table->getParentRedirectField();
+        $relation = $table->getParentRelationField();
+
+        if (empty($redirect)) {
+            return $result;
+        }
+
+        if ($redirect == 'parent') {
+            $result = [
+                'controller' => $module,
+                'action' => 'view',
+                $entity->{$relation}
+            ];
+        }
+
+        if ($redirect == 'self') {
+            $result = ['action' => 'view', $entity->id];
+        }
+
+        return $result;
+    }
+
+    /**
      * getReminderTypeFields
      * @return array $result containing reminder fieldnames
      */


### PR DESCRIPTION
Basic implementation of custom redirects.
Parent redirects work in two main ways:
```ini
[parent]
redirect=parent
module=Parents
relation=parent_id
```
In the above example, upon saving/editing the child record, the user will be redirected to parents controller:
```php
[
  'controller' => 'Parents',
  'action' => 'view',
   $entity->parent_id,
]
```

In case redirect is specified as `self`, the user will be redirected to default `controller/view/entity_id` page. This logic preserved as default.