### PR TITLE
Adding alias titles for pages (task #2520)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -6,6 +6,7 @@ use Cake\Event\EventManager;
 use CsvMigrations\Events\AddViewListener;
 use CsvMigrations\Events\EditViewListener;
 use CsvMigrations\Events\IndexViewListener;
+use CsvMigrations\Events\LayoutListener;
 use CsvMigrations\Events\ViewMenuListener;
 use CsvMigrations\Events\ViewViewListener;
 use CsvMigrations\Events\ReportListener;
@@ -33,6 +34,7 @@ Configure::write('CsvMigrations.api', [
 EventManager::instance()->on(new AddViewListener());
 EventManager::instance()->on(new EditViewListener());
 EventManager::instance()->on(new IndexViewListener());
+EventManager::instance()->on(new LayoutListener());
 EventManager::instance()->on(new ViewMenuListener());
 EventManager::instance()->on(new ViewViewListener());
 EventManager::instance()->on(new ReportListener());

--- a/src/Events/LayoutListener.php
+++ b/src/Events/LayoutListener.php
@@ -1,0 +1,39 @@
+<?php
+namespace CsvMigrations\Events;
+
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\ORM\TableRegistry;
+
+class LayoutListener implements EventListenerInterface
+{
+    /**
+     * Implemented Events
+     * @return array
+     */
+    public function implementedEvents()
+    {
+        return [
+            'QoboAdminPanel.Layout.Head' => 'getMyHead'
+
+        ];
+    }
+
+    /**
+     * getAllReports method
+     * In case we're operating with dynamic CSV tables,
+     * we want to overwrite the page title to be used as moduleAlias().
+     *
+     * @param Cake\Event\Event $event used for getting reports
+     * @return void
+     */
+    public function getMyHead(Event $event)
+    {
+        $table = TableRegistry::get($event->subject()->request['controller']);
+        if ($table) {
+            if (method_exists($table, 'moduleAlias') && is_callable([$table, 'moduleAlias'])) {
+                $event->subject()->assign('title', $table->moduleAlias());
+            }
+        }
+    }
+}


### PR DESCRIPTION
If we're using Qobo-admin-panel plugin for rendering view, we can overwrite the title, for using table aliases, that's more friendly for the users.