### PR TITLE
Fixing tab events (task #3142)

### DIFF
--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -31,9 +31,8 @@ class ViewViewTabsListener implements EventListenerInterface
     {
         return [
             'CsvMigrations.View.View.Tabs' => 'getViewTabs',
-
             'CsvMigrations.View.View.TabsList' => 'getTabsList',
-            'CsvMigrations.View.View.TabContent.beforeContent' => 'getBeforeTabContent',
+            //'CsvMigrations.View.View.TabContent.beforeContent' => 'getBeforeTabContent',
             'CsvMigrations.View.View.TabContent' => 'getTabContent',
             'CsvMigrations.View.View.TabContent.afterContent' => 'getAfterTabContent',
         ];
@@ -45,9 +44,21 @@ class ViewViewTabsListener implements EventListenerInterface
      * @param array $data - containing tab content
      * @return void
      */
-    public function getBeforeTabContent(Event $event, array $data)
+    public function getBeforeTabContent(Event $event, $request, $entity, $options)
     {
-        return $data;
+        $result = [
+          'title' => __('beforeTab Title'),
+          'content' => [
+            'records' => [],
+            'length' => 0,
+          ],
+          'options' => [
+            'displayTemplate' => 'panel_table',
+            'order' => 'beforeTabContent',
+            ],
+        ];
+
+        return $result;
     }
 
     /**

--- a/src/Template/Cell/TabContent/display.ctp
+++ b/src/Template/Cell/TabContent/display.ctp
@@ -12,52 +12,53 @@ Loading Linking Element (typeahead, link, plus components)
 only for many-to-many relationship, as for others
 we don't do the linkage - they would have hidden ID by default
 */
-$emField = $content['class_name'] . '.' . $content['foreign_key'];
-$emFieldName = substr($emField, strrpos($emField, '.') + 1);
-
-$emDataTarget = Inflector::underscore(str_replace('.', '_', $emField));
-$emModal = sprintf("%s_modal", $emDataTarget);
-
-list($emPlugin, $emController) = pluginSplit(substr($emField, 0, strrpos($emField, '.')));
-
-$tableName = $this->request->controller;
-if (!is_null($this->request->plugin)) {
-    $tableName = $this->request->plugin . '.' . $tableName;
-}
-
-$formOptions = [
-    'url' => [
-        'plugin' => $this->request->plugin,
-        'controller' => $this->request->controller,
-        'action' => 'edit',
-        $this->request->pass[0]
-    ]
-];
-
-$handlerOptions = [];
-/*
-set associated table name to be used on input field's name
- */
-$handlerOptions['associated_table_name'] = $content['table_name'];
-/*
-set embedded modal flag
- */
-$handlerOptions['embModal'] = true;
-$handlerOptions['emDataTarget'] = $emDataTarget;
-$handlerOptions['emAssociationType'] = $data['tab']['associationType'];
-/*
-set field type to 'has_many' and default parameters
- */
-$handlerOptions['fieldDefinitions']['type'] = 'has_many(' . $content['class_name'] . ')';
-$handlerOptions['fieldDefinitions']['required'] = true;
-$handlerOptions['fieldDefinitions']['non-searchable'] = true;
-$handlerOptions['fieldDefinitions']['unique'] = false;
-
 ?>
 <?php if (in_array($data['tab']['associationType'], ['manyToMany'])) : ?>
 <div class="row">
     <div class="typeahead-container col-md-4 col-md-offset-8">
     <?php
+        $emField = $content['class_name'] . '.' . $content['foreign_key'];
+        $emFieldName = substr($emField, strrpos($emField, '.') + 1);
+
+        $emDataTarget = Inflector::underscore(str_replace('.', '_', $emField));
+        $emModal = sprintf("%s_modal", $emDataTarget);
+
+        list($emPlugin, $emController) = pluginSplit(substr($emField, 0, strrpos($emField, '.')));
+
+        $tableName = $this->request->controller;
+        if (!is_null($this->request->plugin)) {
+            $tableName = $this->request->plugin . '.' . $tableName;
+        }
+
+        $formOptions = [
+            'url' => [
+                'plugin' => $this->request->plugin,
+                'controller' => $this->request->controller,
+                'action' => 'edit',
+                $this->request->pass[0]
+            ]
+        ];
+
+        $handlerOptions = [];
+        /*
+        set associated table name to be used on input field's name
+         */
+        $handlerOptions['associated_table_name'] = $content['table_name'];
+        /*
+        set embedded modal flag
+         */
+        $handlerOptions['embModal'] = true;
+        $handlerOptions['emDataTarget'] = $emDataTarget;
+        $handlerOptions['emAssociationType'] = $data['tab']['associationType'];
+        /*
+        set field type to 'has_many' and default parameters
+         */
+        $handlerOptions['fieldDefinitions']['type'] = 'has_many(' . $content['class_name'] . ')';
+        $handlerOptions['fieldDefinitions']['required'] = true;
+        $handlerOptions['fieldDefinitions']['non-searchable'] = true;
+        $handlerOptions['fieldDefinitions']['unique'] = false;
+
+
         echo $this->Form->create(null, $formOptions);
            /*
         display typeahead field for associated module(s)
@@ -110,6 +111,10 @@ $handlerOptions['fieldDefinitions']['unique'] = false;
     </div> <!-- modal-dialog -->
 </div> <!-- modal window -->
 <?php endif; ?>
+<?php
+    //@NOTE: if no records were found Query returns null, so we're fixing the count!
+    $content['length'] = (!is_null($content['records'])) ?: 0;
+?>
 <?php if ($content['length']) : ?>
 <div class="table-responsive">
     <table class="table table-hover <?= $data['tab']['containerId']?>">

--- a/src/Template/Cell/TabContent/panel.ctp
+++ b/src/Template/Cell/TabContent/panel.ctp
@@ -1,16 +1,16 @@
 <?php
-$title = (!empty($data['content']['title'])) ? $data['content']['title'] : '';
+$title = (!empty($data['title'])) ? $data['title'] : '';
 
-if (!empty($data['content']['data'])) :
+if (!empty($data['content']['records'])) :
 ?>
 <div class="panel panel-default">
     <div class="panel-heading">
         <h3 class="panel-title"><?= $title ?></h3>
     </div>
     <div class="panel-body">
-        <?php if (!empty($data['content']['data'])) : ?>
+        <?php if (!empty($data['content']['records'])) : ?>
         <table class="table table-hover">
-            <?php foreach ($data['content']['data'] as $row) :?>
+            <?php foreach ($data['content']['records'] as $row) :?>
                 <tr>
                     <?php foreach ($row as $k => $cell) : ?>
                         <td><?= $cell ?> </td>

--- a/src/Template/Element/View/view.ctp
+++ b/src/Template/Element/View/view.ctp
@@ -221,21 +221,23 @@ if (empty($options['title'])) {
                     <div role="tabpanel" class="tab-pane <?= ($k == 0) ? 'active' : ''?>" id="<?= $tab['containerId']?>">
                         <?php
                             $beforeTabContentEvent = new Event('CsvMigrations.View.View.TabContent.beforeContent', $this, [
-                                'data' => [
-                                    'options' => $tab,
-                                    'request' => $this->request,
-                                ],
+                                'request' => $this->request,
+                                'entity'  => $options['entity'],
+                                'options' => [
+                                        'tab' => $tab
+                                    ]
                             ]);
 
                             $this->eventManager()->dispatch($beforeTabContentEvent);
                             $beforeTab = $beforeTabContentEvent->result;
 
-                            if (!empty($beforeTab)) {
+                            if (isset($beforeTab['content']['length']) && count($beforeTab['content']['length']) > 0) {
                                 echo $this->cell('CsvMigrations.TabContent', [
                                     [
                                         'request' => $this->request,
-                                        'content' => $beforeTab,
+                                        'content' => $beforeTab['content'],
                                         'tab' => $tab,
+                                        'options' => ['order' => 'beforeContent'],
                                     ]
                                 ]);
                             }
@@ -257,7 +259,7 @@ if (empty($options['title'])) {
                                         'request' => $this->request,
                                         'content' => $content,
                                         'tab' => $tab,
-                                        'options' => [],
+                                        'options' => ['order' => 'tabContent'],
                                     ]
                                 ]);
 

--- a/src/View/Cell/TabContentCell.php
+++ b/src/View/Cell/TabContentCell.php
@@ -23,7 +23,7 @@ class TabContentCell extends Cell
      * List of accessible displayTemplates for TabContent
      * @var array
      */
-    protected $_displayTemplates = ['display', 'panelTable'];
+    protected $_displayTemplates = ['display', 'panel'];
 
 
     /**
@@ -67,17 +67,15 @@ class TabContentCell extends Cell
     {
         $this->template = $this->_getDisplayTemplate($data['content']);
 
-        if (empty($data['content']['options']) && !isset($data['content']['options']['order'])) {
-            if ($data['content']['records'] instanceof ResultSet) {
-                $data['content']['length'] = $data['content']['records']->count();
-                $data['content']['records'] = $data['content']['records']->toArray();
-            } elseif ($data['content']['records'] instanceof Entity) {
-                $tmp[] = $data['content']['records'];
-                $data['content']['records'] = $tmp;
-                $data['content']['length'] = count($data['content']['records']);
-            } elseif (is_array($data['content'])) {
-                $data['content']['length'] = count($data['content']['records']);
-            }
+        if ($data['content']['records'] instanceof ResultSet) {
+            $data['content']['length'] = $data['content']['records']->count();
+            $data['content']['records'] = $data['content']['records']->toArray();
+        } elseif ($data['content']['records'] instanceof Entity) {
+            $tmp[] = $data['content']['records'];
+            $data['content']['records'] = $tmp;
+            $data['content']['length'] = count($data['content']['records']);
+        } elseif (is_array($data['content']['records'])) {
+            $data['content']['length'] = count($data['content']['records']);
         }
 
         $this->set(compact('data'));

--- a/src/View/Cell/TabContentCell.php
+++ b/src/View/Cell/TabContentCell.php
@@ -65,7 +65,9 @@ class TabContentCell extends Cell
      */
     public function display(array $data)
     {
-        $this->template = $this->_getDisplayTemplate($data['content']);
+        if (isset($data['content'])) {
+            $this->template = $this->_getDisplayTemplate($data['content']);
+        }
 
         if ($data['content']['records'] instanceof ResultSet) {
             $data['content']['length'] = $data['content']['records']->count();

--- a/src/View/Cell/TabContentCell.php
+++ b/src/View/Cell/TabContentCell.php
@@ -69,15 +69,17 @@ class TabContentCell extends Cell
             $this->template = $this->_getDisplayTemplate($data['content']);
         }
 
-        if ($data['content']['records'] instanceof ResultSet) {
-            $data['content']['length'] = $data['content']['records']->count();
-            $data['content']['records'] = $data['content']['records']->toArray();
-        } elseif ($data['content']['records'] instanceof Entity) {
-            $tmp[] = $data['content']['records'];
-            $data['content']['records'] = $tmp;
-            $data['content']['length'] = count($data['content']['records']);
-        } elseif (is_array($data['content']['records'])) {
-            $data['content']['length'] = count($data['content']['records']);
+        if (isset($data['content']['records'])) {
+            if ($data['content']['records'] instanceof ResultSet) {
+                $data['content']['length'] = $data['content']['records']->count();
+                $data['content']['records'] = $data['content']['records']->toArray();
+            } elseif ($data['content']['records'] instanceof Entity) {
+                $tmp[] = $data['content']['records'];
+                $data['content']['records'] = $tmp;
+                $data['content']['length'] = count($data['content']['records']);
+            } elseif (is_array($data['content']['records'])) {
+                $data['content']['length'] = count($data['content']['records']);
+            }
         }
 
         $this->set(compact('data'));


### PR DESCRIPTION
The issue was caused by incorrectly handling the data of the event.
* Event data passed/returned was standardized, to avoid collisions within TabContentCell
* Using `display` default method with custom templates passed, gets broken with camel/snake cased custom template names, thus had to simplify template name.