### PR TITLE
Hide belongsto associations

### DIFF
--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -119,6 +119,11 @@ class ViewViewTabsListener implements EventListenerInterface
                 'targetClass' => $association->className(),
             ];
 
+            // no need to show BelongsTo tabs.
+            // The relationship is shown via the field in the main view.
+            if (in_array($tab['associationObject'], ['BelongsTo'])) {
+                continue;
+            }
 
             if (in_array($association->alias(), array_keys($labels))) {
                 $tab['label'] = $labels[$association->alias()];


### PR DESCRIPTION
We hide most of the BelongsTo associations as they connect are shown in the view element of the records in `view.ctp` already, no need to show it in the relationship tabs.

Re-arrangement of the namings for the tab labels to make it more user-friendly.