### PR TITLE
custom tab names were not added into the labels

### DIFF
--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -156,6 +156,7 @@ class ViewViewTabsListener implements EventListenerInterface
         foreach ($tableInstance->associations() as $association) {
             // If label exists in config.ini, use it.
             if (in_array($association->alias(), array_keys($associationLabels))) {
+                $labels[$association->alias()] = $associationLabels[$association->alias()];
                 continue;
             }
 


### PR DESCRIPTION
We only skipped the tabs, but not actually assigned its config.ini value.