### PR TITLE
return empty result if no parent section is present in config.ini

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -112,26 +112,27 @@ class Table extends BaseTable
         }
 
         $config = $table->getConfig();
-        $table->parentSection($config['parent']);
+        if (isset($config['parent'])) {
+            $table->parentSection($config['parent']);
+            $module = $table->getParentModuleField();
+            $redirect = $table->getParentRedirectField();
+            $relation = $table->getParentRelationField();
 
-        $module = $table->getParentModuleField();
-        $redirect = $table->getParentRedirectField();
-        $relation = $table->getParentRelationField();
+            if (empty($redirect)) {
+                return $result;
+            }
 
-        if (empty($redirect)) {
-            return $result;
-        }
+            if ($redirect == 'parent') {
+                $result = [
+                    'controller' => $module,
+                    'action' => 'view',
+                    $entity->{$relation}
+                ];
+            }
 
-        if ($redirect == 'parent') {
-            $result = [
-                'controller' => $module,
-                'action' => 'view',
-                $entity->{$relation}
-            ];
-        }
-
-        if ($redirect == 'self') {
-            $result = ['action' => 'view', $entity->id];
+            if ($redirect == 'self') {
+                $result = ['action' => 'view', $entity->id];
+            }
         }
 
         return $result;


### PR DESCRIPTION
If we don't have any `parent` section in config.ini, we return the empty `$result` array, so the redirect logic will be held within controller's method (add/edit).