### PR TITLE
Test Fixtures column length

### DIFF
--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -12,7 +12,7 @@ class ArticlesFixture extends TestFixture
 
     public $fields = [
         'id' => ['type' => 'uuid'],
-        'name' => ['type' => 'string', 'length' => 255, 'null' => false],
+        'name' => ['type' => 'string', 'length' => 100, 'null' => false],
         'created' => ['type' => 'datetime', 'null' => true],
         'modified' => ['type' => 'datetime', 'null' => true],
         'trashed' => ['type' => 'datetime', 'null' => true],

--- a/tests/Fixture/FooFixture.php
+++ b/tests/Fixture/FooFixture.php
@@ -13,7 +13,7 @@ class FooFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'uuid'],
         'description' => ['type' => 'text', 'null' => true],
-        'name' => ['type' => 'string', 'length' => 255, 'null' => false],
+        'name' => ['type' => 'string', 'length' => 100, 'null' => false],
         'status' => ['type' => 'string', 'length' => 255, 'null' => false],
         'type' => ['type' => 'string', 'length' => 255, 'null' => false],
         'gender' => ['type' => 'string', 'length' => 255, 'null' => true],


### PR DESCRIPTION
Decreased column length to avoid following sql error:
`1071 Specified key was too long`