### PR TITLE
Added support for module icons (task #3154)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -19,6 +19,7 @@ Configure::write('CsvMigrations.views.path', CONFIG . 'CsvMigrations' . DS . 'vi
 Configure::write('CsvMigrations.lists.path', CONFIG . 'CsvMigrations' . DS . 'lists' . DS);
 Configure::write('CsvMigrations.migrations.filename', 'migration');
 Configure::write('CsvMigrations.reports.filename', 'reports');
+Configure::write('CsvMigrations.default_icon', 'cube');
 Configure::write('CsvMigrations.typeahead.min_length', 1);
 Configure::write('CsvMigrations.typeahead.timeout', 300);
 Configure::write('CsvMigrations.acl', [

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -183,7 +183,7 @@ trait ConfigurationTrait
         return $this->_searchable;
     }
 
-     /**
+    /**
      * Returns the module icon or sets a new one
      *
      * @param string|null $icon sets the icon
@@ -192,7 +192,7 @@ trait ConfigurationTrait
     public function icon($icon = null)
     {
         if ($icon !== null) {
-            $this->_icon = (string) $icon;
+            $this->_icon = (string)$icon;
         }
 
         // Default icon if none is set

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -23,6 +23,12 @@ trait ConfigurationTrait
     protected $_searchable = false;
 
     /**
+     * Module icon
+     *
+     * @var string
+     */
+    protected $_icon;
+    /**
      * Lookup fields used for fetching record(s) through the API
      *
      * @var array
@@ -115,6 +121,11 @@ trait ConfigurationTrait
             $this->displayField($this->_config['table']['display_field']);
         }
 
+        // module icon from configuration file
+        if (isset($this->_config['table']['icon'])) {
+            $this->icon($this->_config['table']['icon']);
+        }
+
         // lookup field(s) from configuration file
         if (isset($this->_config['table']['lookup_fields'])) {
             $this->lookupFields($this->_config['table']['lookup_fields']);
@@ -170,6 +181,26 @@ trait ConfigurationTrait
         }
 
         return $this->_searchable;
+    }
+
+     /**
+     * Returns the module icon or sets a new one
+     *
+     * @param string|null $icon sets the icon
+     * @return string
+     */
+    public function icon($icon = null)
+    {
+        if ($icon !== null) {
+            $this->_icon = (string) $icon;
+        }
+
+        // Default icon if none is set
+        if (empty($this->_icon)) {
+            $this->_icon = Configure::read('CsvMigrations.default_icon');
+        }
+
+        return $this->_icon;
     }
 
     /**

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -23,6 +23,19 @@ class ConfigurationTraitTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->mock->isSearchable('foobar'));
     }
 
+    public function testIcon()
+    {
+        // Default icon
+        $expected = \Cake\Core\Configure::read('CsvMigration.default_icon');
+        $this->assertEquals($expected, $this->mock->icon());
+
+        // Setting icon
+        $expected = 'foobar';
+        $this->assertEquals($expected, $this->mock->icon($expected));
+        // Getting icon
+        $this->assertEquals($expected, $this->mock->icon());
+    }
+
     public function testModuleAlias()
     {
         $this->assertSame($this->mock->moduleAlias('foo'), 'foo');


### PR DESCRIPTION
Each module can now be assigned an icon via the `config.ini` like
so:

```
[table]
icon = foobar
```

For those modules that are missing icon configuration, a default
icon is used ('cube').