### PR TITLE
Minor improvements for module icon (task #3155)

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -9,6 +9,13 @@ use CsvMigrations\PathFinder\ConfigPathFinder;
 trait ConfigurationTrait
 {
     /**
+     * Default icon
+     *
+     * When all else fails, use this icon.
+     */
+    public $defaultIcon = 'cube';
+
+    /**
      * Table/module configuration
      *
      * @var array
@@ -197,7 +204,13 @@ trait ConfigurationTrait
 
         // Default icon if none is set
         if (empty($this->_icon)) {
-            $this->_icon = Configure::read('CsvMigrations.default_icon');
+            $this->_icon = (string)Configure::read('CsvMigrations.default_icon');
+        }
+
+        // To avoid unncessary checks in the views for the missing
+        // icon, we should ALWAYS return something.
+        if (empty($this->_icon)) {
+            $this->_icon = $this->defaultIcon;
         }
 
         return $this->_icon;

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -436,6 +436,7 @@ class ValidateShell extends Shell
     protected function _checkConfigOptions(array $modules = [])
     {
         $errors = [];
+        $warnings = [];
 
         $this->out('Checking configuration options:', 2);
         foreach ($modules as $module => $path) {
@@ -460,6 +461,13 @@ class ValidateShell extends Shell
                         if (!$this->_isValidModuleField($module, $config['table']['display_field'])) {
                             $moduleErrors[] = $module . " config [table] section references unknown field '" . $config['table']['display_field'] . "' in 'display_field' key";
                         }
+                    }
+                    else {
+                        $warnings[] = $module . " config [table] section does not specify 'display_field' key";
+                    }
+                    // 'icon' key is optional, but strongly suggested
+                    if (empty($config['table']['icon'])) {
+                        $warnings[] = $module . " config [table] section does not specify 'icon' key";
                     }
                     // 'typeahead_fields' key is optional, but must contain valid fields if specified
                     if (!empty($config['table']['typeahead_fields'])) {
@@ -585,7 +593,7 @@ class ValidateShell extends Shell
             $this->out($result);
             $errors = array_merge($errors, $moduleErrors);
         }
-        $this->_printCheckStatus($errors);
+        $this->_printCheckStatus($errors, $warnings);
 
         return count($errors);
     }

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -461,8 +461,7 @@ class ValidateShell extends Shell
                         if (!$this->_isValidModuleField($module, $config['table']['display_field'])) {
                             $moduleErrors[] = $module . " config [table] section references unknown field '" . $config['table']['display_field'] . "' in 'display_field' key";
                         }
-                    }
-                    else {
+                    } else {
                         $warnings[] = $module . " config [table] section does not specify 'display_field' key";
                     }
                     // 'icon' key is optional, but strongly suggested

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -26,8 +26,13 @@ class ConfigurationTraitTest extends PHPUnit_Framework_TestCase
     public function testIcon()
     {
         // Default icon
-        $expected = \Cake\Core\Configure::read('CsvMigration.default_icon');
-        $this->assertEquals($expected, $this->mock->icon());
+        $expected = \Cake\Core\Configure::read('CsvMigrations.default_icon');
+
+        // Only test default values if they are configured, to avoid
+        // failures in integration tests.
+        if (!empty($expected)) {
+            $this->assertEquals($expected, $this->mock->icon(), "Default icon does not return CsvMigrations.default_icon");
+        }
 
         // Setting icon
         $expected = 'foobar';

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -28,12 +28,12 @@ class ConfigurationTraitTest extends PHPUnit_Framework_TestCase
         // Default icon
         $expected = \Cake\Core\Configure::read('CsvMigrations.default_icon');
 
-        // Only test default values if they are configured, to avoid
-        // failures in integration tests.
         if (empty($expected)) {
-            $this->markTestSkipped("CsvMigrations.default_icon is not configured");
+            $expected = $this->mock->defaultIcon;
         }
-        $this->assertEquals($expected, $this->mock->icon(), "Default icon does not return CsvMigrations.default_icon");
+
+        $this->assertFalse(empty($expected), "Failed to find the fallback for the default icon");
+        $this->assertEquals($expected, $this->mock->icon());
     }
 
     public function testIcon()

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -23,17 +23,21 @@ class ConfigurationTraitTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->mock->isSearchable('foobar'));
     }
 
-    public function testIcon()
+    public function testIconDefault()
     {
         // Default icon
         $expected = \Cake\Core\Configure::read('CsvMigrations.default_icon');
 
         // Only test default values if they are configured, to avoid
         // failures in integration tests.
-        if (!empty($expected)) {
-            $this->assertEquals($expected, $this->mock->icon(), "Default icon does not return CsvMigrations.default_icon");
+        if (empty($expected)) {
+            $this->markTestSkipped("CsvMigrations.default_icon is not configured");
         }
+        $this->assertEquals($expected, $this->mock->icon(), "Default icon does not return CsvMigrations.default_icon");
+    }
 
+    public function testIcon()
+    {
         // Setting icon
         $expected = 'foobar';
         $this->assertEquals($expected, $this->mock->icon($expected));


### PR DESCRIPTION
* Improved handling of the default icon and cases when its configuration is missing.
* Added icon check (warning) to the Validator shell.
* Improved unit tests and fixed the issue with the integration test fails.