### PR TITLE
Notifications config (task #2719)

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -95,6 +95,16 @@ trait ConfigurationTrait
     protected $_moduleAlias;
 
     /**
+     * Notifications config
+     *
+     * @var array
+     */
+    protected $_notifications = [
+        'enable' => false,
+        'ignored_fields' => []
+    ];
+
+    /**
      * Method that returns table configuration.
      *
      * @return array
@@ -160,6 +170,10 @@ trait ConfigurationTrait
 
         if (isset($this->_config['parent'])) {
             $this->parentSection($this->_config['parent']);
+        }
+
+        if (isset($this->_config['notifications'])) {
+            $this->notifications($this->_config['notifications']);
         }
 
         // set virtual field(s)
@@ -331,6 +345,40 @@ trait ConfigurationTrait
         }
 
         return $this->_associationLabels;
+    }
+
+    /**
+     * Returns notifications config or sets a new one.
+     *
+     * @param array $notifications sets notifications config
+     * @return array
+     */
+    public function notifications($notifications = [])
+    {
+        if (!empty($notifications)) {
+            foreach ($this->_notifications as $k => $v) {
+                if (empty($notifications[$k])) {
+                    continue;
+                }
+
+                $type = gettype($v);
+
+                $v = $notifications[$k];
+                switch ($type) {
+                    case 'boolean':
+                        $v = (bool)$v;
+                        break;
+
+                    case 'array':
+                        $v = is_string($v) ? explode(',', $v) : $v;
+                        break;
+                }
+
+                $this->_notifications[$k] = $v;
+            }
+        }
+
+        return $this->_notifications;
     }
 
     /**

--- a/src/FieldHandlers/DateFieldHandler.php
+++ b/src/FieldHandlers/DateFieldHandler.php
@@ -1,7 +1,7 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
-use Cake\I18n\Time;
+use Cake\I18n\Date;
 use CsvMigrations\FieldHandlers\BaseFieldHandler;
 
 class DateFieldHandler extends BaseFieldHandler
@@ -32,7 +32,7 @@ class DateFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
-        if ($data instanceof Time) {
+        if ($data instanceof Date) {
             $data = $data->i18nFormat(static::DATE_FORMAT);
         }
 

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -551,6 +551,20 @@ class ValidateShell extends Shell
                         }
                     }
                 }
+
+                // [notifications] section
+                if (!empty($config['notifications'])) {
+                    // 'ignored_fields' key is optional, but must contain valid fields if specified
+                    if (!empty($config['notifications']['ignored_fields'])) {
+                        $ignoredFields = explode(',', trim($config['notifications']['ignored_fields']));
+                        foreach ($ignoredFields as $ignoredField) {
+                            if (!$this->_isValidModuleField($module, $ignoredField)) {
+                                $moduleErrors[] = $module . " config [notifications] section references unknown field '" . $ignoredField . "' in 'typeahead_fields' key";
+                            }
+                        }
+                    }
+                }
+
                 // [conversion] section
                 if (!empty($config['conversion'])) {
                     // 'module' key is required and must contain valid modules

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -23,6 +23,25 @@ class ConfigurationTraitTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->mock->isSearchable('foobar'));
     }
 
+    public function testNotifications()
+    {
+        $expected = [
+            'enable' => true,
+            'ignored_fields' => ['foo', 'bar']
+        ];
+
+        $expectedAsString = [
+            'enable' => true,
+            'ignored_fields' => 'foo,bar'
+        ];
+
+        $this->assertEquals($expected, $this->mock->notifications($expected));
+        $this->assertEquals($expected, $this->mock->notifications());
+
+        $this->assertEquals($expected, $this->mock->notifications($expectedAsString));
+        $this->assertEquals($expected, $this->mock->notifications());
+    }
+
     public function testIconDefault()
     {
         // Default icon


### PR DESCRIPTION
Added support for notifications config. Current parameters are `enable` and `ignore_fields`. Enable expects a boolean value and ignore_fields expects a comma separated string of fields. See example below:
```ini
[notifications]
enable = true
ignored_fields = name,status
```