### PR TITLE
Fixing panel title in beforeContent event

### DIFF
--- a/src/Template/Cell/TabContent/panel.ctp
+++ b/src/Template/Cell/TabContent/panel.ctp
@@ -1,5 +1,5 @@
 <?php
-$title = (!empty($data['title'])) ? $data['title'] : '';
+$title = (!empty($data['options']['title'])) ? $data['options']['title'] : '';
 
 if (!empty($data['content']['records'])) :
 ?>

--- a/src/Template/Element/View/view.ctp
+++ b/src/Template/Element/View/view.ctp
@@ -237,7 +237,7 @@ if (empty($options['title'])) {
                                         'request' => $this->request,
                                         'content' => $beforeTab['content'],
                                         'tab' => $tab,
-                                        'options' => ['order' => 'beforeContent'],
+                                        'options' => ['order' => 'beforeContent','title' => $beforeTab['title']],
                                     ]
                                 ]);
                             }


### PR DESCRIPTION
Title wasn't passed properly for the beforeContent event listener