### PR TITLE
vCal Email (task #3180)

### DIFF
--- a/src/Events/ModelAfterSaveListener.php
+++ b/src/Events/ModelAfterSaveListener.php
@@ -83,6 +83,10 @@ class ModelAfterSaveListener implements EventListenerInterface
         }
 
         $attendeesFields = $this->_getAttendeesFields($table, ['tables' => $remindersTo]);
+        // skip if no attendees fields found
+        if (empty($attendeesFields)) {
+            return $sent;
+        }
 
         // skip if none of the required fields was modified
         $requiredFields = array_merge((array)$reminderField, $attendeesFields);

--- a/src/Events/ModelAfterSaveListener.php
+++ b/src/Events/ModelAfterSaveListener.php
@@ -16,7 +16,7 @@ class ModelAfterSaveListener implements EventListenerInterface
     /**
      * Changelog template
      */
-    const CHANGELOG = '* %s: changed from "%s" to "%s".';
+    const CHANGELOG = '* %s: changed from "%s" to "%s".' . "\n";
 
     /**
      * Ingored modified fields
@@ -326,7 +326,7 @@ class ModelAfterSaveListener implements EventListenerInterface
         }
 
         foreach ($fields as $k => $v) {
-            $result .= sprintf(static::CHANGELOG, Inflector::humanize($k), $v, $entity->{$k}) . "\n";
+            $result .= sprintf(static::CHANGELOG, Inflector::humanize($k), $v, $entity->{$k});
         }
 
         return $result;

--- a/src/Events/ModelAfterSaveListener.php
+++ b/src/Events/ModelAfterSaveListener.php
@@ -43,10 +43,15 @@ class ModelAfterSaveListener implements EventListenerInterface
 
         $table = $event->subject();
 
-        //get attendees for the event
+        //get attendees Table for the event
         if (method_exists($table, 'getConfig') && is_callable([$table, 'getConfig'])) {
             $config = $table->getConfig();
             $remindersTo = $table->getTableAllowRemindersField();
+        }
+
+        // skip if attendees Table is not defined
+        if (empty($remindersTo)) {
+            return $sent;
         }
 
         // Figure out which field is a reminder one
@@ -61,10 +66,6 @@ class ModelAfterSaveListener implements EventListenerInterface
         $reminderField = $reminderField['name'];
         // Skip sending email if reminder field is empty
         if (empty($entity->$reminderField)) {
-            return $sent;
-        }
-
-        if (empty($remindersTo)) {
             return $sent;
         }
 

--- a/src/Events/ModelAfterSaveListener.php
+++ b/src/Events/ModelAfterSaveListener.php
@@ -130,8 +130,10 @@ class ModelAfterSaveListener implements EventListenerInterface
             $currentUser = $table->getCurrentUser();
             $emailContent .= " by " . $currentUser['email'];
         }
-        // append changelog
-        $emailContent .= "\n\n" . $this->_getChangelog($entity);
+        // append changelog if entity is not new
+        if (!$entity->isNew()) {
+            $emailContent .= "\n\n" . $this->_getChangelog($entity);
+        }
 
         foreach ($emails as $email) {
             $vCalendar = new \Eluceo\iCal\Component\Calendar('//EN//');
@@ -309,12 +311,13 @@ class ModelAfterSaveListener implements EventListenerInterface
     {
         $result = '';
 
-        // get entity's modified fields
+        // plain changelog if entity is new
         if ($entity->isNew()) {
-            $fields = $entity->extractOriginal($entity->visibleProperties());
-        } else {
-            $fields = $entity->extractOriginalChanged($entity->visibleProperties());
+            return $result;
         }
+
+        // get entity's modified fields
+        $fields = $entity->extractOriginalChanged($entity->visibleProperties());
 
         if (empty($fields)) {
             return $result;

--- a/src/Events/ModelAfterSaveListener.php
+++ b/src/Events/ModelAfterSaveListener.php
@@ -69,6 +69,8 @@ class ModelAfterSaveListener implements EventListenerInterface
             return $sent;
         }
 
+        $attendeesFields = $this->_getAttendeesFields($table, ['tables' => $remindersTo]);
+
         /*
          * Figure out the subject of the email
          *
@@ -139,6 +141,41 @@ class ModelAfterSaveListener implements EventListenerInterface
         }
 
         return $sent;
+    }
+
+    /**
+     * Retrieve attendees fields from current Table's associations.
+     *
+     * @param \Cake\ORM\Table $table Table instance
+     * @param array $options Options
+     * @return array
+     */
+    protected function _getAttendeesFields(Table $table, $options = [])
+    {
+        $result = [];
+
+        $associations = [];
+        if (!empty($options['tables'])) {
+            foreach ($table->associations() as $association) {
+                if (!in_array(Inflector::humanize($association->target()->table()), $options['tables'])) {
+                    continue;
+                }
+
+                $associations[] = $association;
+            }
+        } else {
+            $associations = $table->associations();
+        }
+
+        if (empty($associations)) {
+            return $result;
+        }
+
+        foreach ($associations as $association) {
+            $result[] = $association->foreignKey();
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Events/ModelAfterSaveListener.php
+++ b/src/Events/ModelAfterSaveListener.php
@@ -16,7 +16,7 @@ class ModelAfterSaveListener implements EventListenerInterface
     /**
      * Changelog template
      */
-    const CHANGELOG = '* %s: changed from \'%s\' to \'%s\'.';
+    const CHANGELOG = '* %s: changed from "%s" to "%s".';
 
     /**
      * Ingored modified fields


### PR DESCRIPTION
* vCal email is now sent only if required fields have been modified.
* vCal email content now includes changelog report (see example below):

Before:
```
Meeting information was updated by user@company.com
```
Now:
```
Meeting information was updated by user@company.com

* Title: changed from 'Foo' to 'Bar'.
* Content: changed from 'Hello World' to 'Hi there'.
```