### PR TITLE
Fixing AJAX upload of files (task #3139)

### DIFF
--- a/config/file_upload.php
+++ b/config/file_upload.php
@@ -12,7 +12,6 @@ Configure::write('CsvMigrations.BootstrapFileInput', [
         'showUploadedThumbs' => true,
         'uploadAsync' => true,
         'dropZoneEnabled' => false,
-        'showUploadedThumbs' => false,
         'fileActionSettings' => [
             'showUpload' => false,
             'showZoom' => false,

--- a/config/file_upload.php
+++ b/config/file_upload.php
@@ -19,7 +19,6 @@ Configure::write('CsvMigrations.BootstrapFileInput', [
         'maxFileCount' => 30,
         'fileSizeGetter' => true,
         'maxFileSize' => 2000,
-        //'uploadUrl' => "/api/%s/upload"
     ],
     'initialPreviewConfig' => [
         'url' => "/api/file-storages/delete/"

--- a/config/file_upload.php
+++ b/config/file_upload.php
@@ -20,7 +20,7 @@ Configure::write('CsvMigrations.BootstrapFileInput', [
         'maxFileCount' => 30,
         'fileSizeGetter' => true,
         'maxFileSize' => 2000,
-        'uploadUrl' => "/api/%s/upload"
+        //'uploadUrl' => "/api/%s/upload"
     ],
     'initialPreviewConfig' => [
         'url' => "/api/file-storages/delete/"

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -228,7 +228,7 @@ class AppController extends Controller
 
         $this->Crud->on('afterSave', function (Event $event) {
             // handle file uploads if found in the request data
-            $linked = $this->_fileUploadsUtils->linkFilesToEntity($event->subject()->entity, $this->{$this->name} , $this->request->data);
+            $linked = $this->_fileUploadsUtils->linkFilesToEntity($event->subject()->entity, $this->{$this->name}, $this->request->data);
 
             $ev = new Event('CsvMigrations.Add.afterSave', $this, [
                 'entity' => $event->subject()->entity
@@ -269,7 +269,7 @@ class AppController extends Controller
 
         $this->Crud->on('afterSave', function (Event $event) {
             // handle file uploads if found in the request data
-            $linked = $this->_fileUploadsUtils->linkFilesToEntity($event->subject()->entity, $this->{$this->name} , $this->request->data);
+            $linked = $this->_fileUploadsUtils->linkFilesToEntity($event->subject()->entity, $this->{$this->name}, $this->request->data);
         });
 
         return $this->Crud->execute();

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -309,7 +309,7 @@ class AppController extends Controller
         }
 
         if ($saved) {
-            $response['id'] = $saved;
+            $response = $saved;
         } else {
             $this->response->statusCode(400);
             $response['errors'] = "Couldn't save the File";

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -228,9 +228,8 @@ class AppController extends Controller
 
         $this->Crud->on('afterSave', function (Event $event) {
             // handle file uploads if found in the request data
-            if (isset($this->request->data['file'])) {
-                $this->_fileUploadsUtils->save($event->subject()->entity, $this->request->data['file']);
-            }
+            $linked = $this->_fileUploadsUtils->linkFilesToEntity($event->subject()->entity, $this->{$this->name} , $this->request->data);
+
             $ev = new Event('CsvMigrations.Add.afterSave', $this, [
                 'entity' => $event->subject()->entity
             ]);
@@ -270,9 +269,7 @@ class AppController extends Controller
 
         $this->Crud->on('afterSave', function (Event $event) {
             // handle file uploads if found in the request data
-            if (isset($this->request->data['file'])) {
-                $this->_fileUploadsUtils->save($event->subject()->entity, $this->request->data['file']);
-            }
+            $linked = $this->_fileUploadsUtils->linkFilesToEntity($event->subject()->entity, $this->{$this->name} , $this->request->data);
         });
 
         return $this->Crud->execute();

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -339,9 +339,11 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
      */
     protected function _getFieldName($table, $field, array $options = [])
     {
+        ///*
         if (isset($options['embedded'])) {
             return $options['embedded'] . '.' . $field;
         }
+        //*/
 
         if (empty($table)) {
             return $field;

--- a/src/FieldHandlers/FilesFieldHandler.php
+++ b/src/FieldHandlers/FilesFieldHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
+use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
@@ -45,16 +46,21 @@ class FilesFieldHandler extends BaseFileFieldHandler
      */
     protected function _renderInputWithoutData($table, $field, $options)
     {
+        debug('a');
         $uploadField = $this->cakeView->Form->file(
             $this->_getFieldName($table, $field, $options) . '[]',
-            ['multiple' => true]
+            [
+                'multiple' => true,
+                'data-upload-url' => sprintf("/api/%s/upload", Inflector::dasherize($table->table())),
+            ]
         );
+
         $label = $this->cakeView->Form->label($field);
 
         $hiddenIds = $this->cakeView->Form->hidden(
             $this->_getFieldName($table, $field, $options) . '_ids][',
             [
-                'class' => Inflector::underscore(str_replace('.', '_', $this->_getFieldName($table, $field, $options) . '_ids')),
+                'class' => str_replace('.', '_', $this->_getFieldName($table, $field, $options) . '_ids'),
                 'value' => ''
             ]
         );
@@ -80,6 +86,14 @@ class FilesFieldHandler extends BaseFileFieldHandler
 
         $entities = $fileUploadsUtils->getFiles($table, $field, $entity->get('id'));
 
+        if ($entities instanceof \Cake\ORM\ResultSet) {
+            if (!$entities->count()) {
+                return $this->_renderInputWithoutData($table, $field, $options);
+            }
+        }
+
+        // @TODO: check if we return null anywhere, apart of ResultSet.
+        // IF NOT: remove this block
         if (is_null($entities)) {
             return $this->_renderInputWithoutData($table, $field, $options);
         }
@@ -93,7 +107,7 @@ class FilesFieldHandler extends BaseFileFieldHandler
             $hiddenIds .= $this->cakeView->Form->hidden(
                 $this->_getFieldName($table, $field, $options) . '_ids][',
                 [
-                    'class' => Inflector::underscore(str_replace('.', '_', $this->_getFieldName($table, $field, $options) . '_ids')),
+                    'class' => str_replace('.', '_', $this->_getFieldName($table, $field, $options) . '_ids'),
                     'value' => $file->id
                 ]
             );
@@ -106,6 +120,7 @@ class FilesFieldHandler extends BaseFileFieldHandler
             [
                 'multiple' => true,
                 'data-document-id' => $entity->get('id'),
+                'data-upload-url' => sprintf("/api/%s/upload", Inflector::dasherize($table->table())),
                 //passed to generate previews
                 'data-files' => json_encode($files),
             ]

--- a/src/FieldHandlers/FilesFieldHandler.php
+++ b/src/FieldHandlers/FilesFieldHandler.php
@@ -46,7 +46,6 @@ class FilesFieldHandler extends BaseFileFieldHandler
      */
     protected function _renderInputWithoutData($table, $field, $options)
     {
-        debug('a');
         $uploadField = $this->cakeView->Form->file(
             $this->_getFieldName($table, $field, $options) . '[]',
             [

--- a/src/FileUploadsUtils.php
+++ b/src/FileUploadsUtils.php
@@ -231,7 +231,7 @@ class FileUploadsUtils
      * @param array $data of this->request->data containing ids.
      * @return mixed $result of saved/updated file entities.
      */
-    public function linkFilesToEntity($entity, $tableInstance, $data = [])
+    public function linkFilesToEntity($entity, $tableInstance, $data = [], $options = [])
     {
         $result = [];
         $uploadFields = [];
@@ -251,23 +251,29 @@ class FileUploadsUtils
         }
 
         foreach ($uploadFields as $field) {
+            $savedIds = [];
             $savedIdsField = $field['name'] . '_ids';
 
+            // @NOTE: in case of AJAX/API calls we don't have data[Table][field]
+            // notation, only data[field].
             if (isset($data[$tableInstance->alias()][$savedIdsField])) {
-                $assocName = CsvMigrationsUtils::createAssociationName('Burzum/FileStorage.FileStorage', $field['name']);
-
                 $savedIds = $data[$tableInstance->alias()][$savedIdsField];
-                $savedIds = array_values(array_filter($savedIds));
+            } else {
+                $savedIds = $data[$savedIdsField];
+            }
 
-                if (empty($savedIds)) {
-                    continue;
-                }
+            if (empty($savedIds)) {
+                continue;
+            }
 
-                foreach ($savedIds as $fileId) {
-                    $record = $this->_table->{$assocName}->get($fileId);
-                    $record->foreign_key = $entity->id;
-                    $result[] = $this->_table->{$assocName}->save($record);
-                }
+            $savedIds = array_values(array_filter($savedIds));
+            $assocName = CsvMigrationsUtils::createAssociationName('Burzum/FileStorage.FileStorage', $field['name']);
+
+            foreach ($savedIds as $fileId) {
+                $record = $this->_table->{$assocName}->get($fileId);
+                $record->foreign_key = $entity->id;
+
+                $result[] = $this->_table->{$assocName}->save($record);
             }
         }
 

--- a/src/FileUploadsUtils.php
+++ b/src/FileUploadsUtils.php
@@ -143,7 +143,10 @@ class FileUploadsUtils
 
             $result = $this->_storeFileStorage($entity, $field, ['file' => $file], $options);
             if ($result) {
-                $result = $result->get('id');
+                $result = [
+                    'id' => $result->get('id'),
+                    'path' => $result->get('path')
+                ];
             }
         }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -201,7 +201,10 @@ class Table extends BaseTable
     public function setAssociatedByLookupFields(Entity $entity, $options = [])
     {
         foreach ($this->associations() as $association) {
-            $lookupFields = $association->target()->lookupFields();
+            $lookupFields = [];
+            if (method_exists($association->target(), 'lookupFields')) {
+                $lookupFields = $association->target()->lookupFields();
+            }
 
             if (empty($lookupFields)) {
                 continue;

--- a/src/Template/Element/common_js_libs.ctp
+++ b/src/Template/Element/common_js_libs.ctp
@@ -21,22 +21,10 @@ echo $this->Html->scriptBlock(
 
 
 $fileInputOptions = Configure::read('CsvMigrations.BootstrapFileInput');
-if (!empty($fileInputOptions)) {
-    $currentController = Inflector::dasherize($this->request->params['controller']);
-
-    if (isset($fileInputOptions['defaults']['uploadUrl'])) {
-        $fileInputOptions['defaults']['uploadUrl'] = sprintf($fileInputOptions['defaults']['uploadUrl'], $currentController);
-    }
-    if (isset($fileInputOptions['initialPreviewConfig']['url'])) {
-        $fileInputOptions['initialPreviewConfig']['url'] = sprintf($fileInputOptions['initialPreviewConfig']['url'], $currentController);
-    }
-
-    echo $this->Html->scriptBlock(
-        'fileInputOptions = ' . json_encode($fileInputOptions) . ';',
-        ['block' => 'scriptBottom']
-    );
-}
-echo $this->Html->script('CsvMigrations.es6-shim.min', ['block' => 'scriptBottom']);
+echo $this->Html->scriptBlock(
+    'fileInputOptions = ' . json_encode($fileInputOptions) . ';',
+    ['block' => 'scriptBottom']
+);
 echo $this->Html->script('CsvMigrations.typeahead', ['block' => 'scriptBottom']);
 echo $this->Html->script('CsvMigrations.embedded', ['block' => 'scriptBottom']);
 echo $this->Html->script('CsvMigrations.panels', ['block' => 'scriptBottom']);

--- a/webroot/js/fileinput-load.js
+++ b/webroot/js/fileinput-load.js
@@ -33,7 +33,7 @@ $(document).ready(function () {
         },
         maxFileCount: 30,
         maxFileSize: 2000,
-        uploadUrl: '/api/file-storages/upload'
+        //uploadUrl: '/api/file-storages/upload'
     };
 
     FileInput.prototype.staticHtml = {
@@ -129,7 +129,7 @@ $(document).ready(function () {
         var fieldNameParts = $(inputField).attr('name').match(/^(\w+)\[(\w+)\]/);
 
         if (fieldNameParts.length) {
-            result = `.${fieldNameParts[1].toLowerCase()}_${fieldNameParts[2].toLowerCase()}_ids`;
+            result = '.' + fieldNameParts[1] + '_' + fieldNameParts[2] + '_ids';
         }
 
         return result;
@@ -145,6 +145,10 @@ $(document).ready(function () {
         var that = this;
         var options = $.extend({}, this.defaults());
 
+        if ($(inputField).attr('data-upload-url')) {
+            options.uploadUrl = $(inputField).attr('data-upload-url');
+        }
+
         inputField.fileinput(options).on("filebatchselected", function (event) {
             $(document).trigger('updateFiles', [event.target.files, $(this).attr('name')]);
         });
@@ -152,7 +156,7 @@ $(document).ready(function () {
         inputField.fileinput(options).on('fileuploaded', function (event, data) {
             if (data.response.id !== undefined) {
                 if (data.response.id.length) {
-                    that.addHiddenFileId($(this), data.response.id);
+                    that.addHiddenFileId(this, data.response.id);
                 }
             }
         }).on('filedeleted', function (event, key) {
@@ -164,9 +168,8 @@ $(document).ready(function () {
         var added = false;
         var found = false;
 
-        var elementId = this.getHiddenField($(inputField));
+        var elementId = this.getHiddenField(inputField);
         var hiddenFields = $.find(elementId);
-
         hiddenFields.forEach(function (element) {
             if ($(element).val() == id) {
                 found = true;
@@ -239,11 +242,18 @@ $(document).ready(function () {
             }
         };
 
-        var options = $.extend({}, this.defaults(), existing);
+        var defaultOptions = this.defaults();
+
+        if ($(inputField).attr('data-upload-url')) {
+            defaultOptions.uploadUrl = $(inputField).attr('data-upload-url');
+        }
+
+        var options = $.extend({}, defaultOptions, existing);
+
         inputField.fileinput(options).on('fileuploaded', function (event, data) {
             if (data.response.id !== undefined) {
                 if (data.response.id.length) {
-                    that.addHiddenFileId($(this), data.response.id);
+                    that.addHiddenFileId(this, data.response.id);
                 }
             }
         }).on('filedeleted', function (event, key) {
@@ -251,7 +261,6 @@ $(document).ready(function () {
         });
     };
 
-  /* initializing the plugin */
     $("input[type=file]").each(function () {
         var files = $(this).data('files');
         var name = $(this).attr('name');

--- a/webroot/js/fileinput-load.js
+++ b/webroot/js/fileinput-load.js
@@ -112,6 +112,7 @@ $(document).ready(function () {
         }
 
         that.options.initialPreviewConfig = filesOptions;
+
         return filesOptions;
     };
 
@@ -119,8 +120,8 @@ $(document).ready(function () {
         var opts = [];
 
         if (ids.length) {
-            ids.forEach( function (id) {
-                opts.push({ key: id, url: '/api/file-storages/delete/' + id});
+            ids.forEach(function (id) {
+                opts.push({key: id, url: '/api/file-storages/delete/' + id});
             });
         }
 
@@ -306,10 +307,9 @@ $(document).ready(function () {
             options.initialPreview = paths;
             that.refreshFileInput(this, options);
         });
-
     };
 
-    FileInput.prototype.refreshFileInput = function(inputField, options) {
+    FileInput.prototype.refreshFileInput = function (inputField, options) {
         $(inputField).fileinput('refresh', options);
     };
 


### PR DESCRIPTION
Issues solved:
* Upon upload while adding a record, 'delete' icon is not functional.
`inputField` element has been refresh to catch all uploaded files during add/edit actions.
* Using `manyToMany` tabbed adding of the record fixed `Api/AppController.php` method to link ajax-uploaded files with the created entity.

 