### PR TITLE
UUID on typeahead (task #3182)

### DIFF
--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -1,6 +1,7 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
+use BadMethodCallException;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
@@ -118,10 +119,16 @@ trait RelatedFieldTrait
      */
     protected function _getAssociatedRecord(Table $table, $value)
     {
-        $query = $table->find('all', [
+        $options = [
             'conditions' => [$table->primaryKey() => $value],
             'limit' => 1
-        ]);
+        ];
+        // try to fetch with trashed if finder method exists, otherwise fallback to find all
+        try {
+            $query = $table->find('withTrashed', $options);
+        } catch (BadMethodCallException $e) {
+            $query = $table->find('all', $options);
+        }
 
         return $query->first();
     }

--- a/src/Template/Element/View/view.ctp
+++ b/src/Template/Element/View/view.ctp
@@ -1,5 +1,6 @@
 <?php
 use Cake\Core\Configure;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
@@ -179,17 +180,21 @@ if (empty($options['title'])) {
                 $embeddedAssocName = Inflector::underscore(Inflector::singularize($embeddedAssocName));
 
                 if (!empty($options['entity']->$embeddedFieldName)) {
-                    echo $this->requestAction(
-                        [
-                            'plugin' => $embeddedPlugin,
-                            'controller' => $embeddedController,
-                            'action' => $this->request->action
-                        ],
-                        [
-                            'query' => ['embedded' => $this->request->controller . '.' . $embeddedAssocName],
-                            'pass' => [$options['entity']->$embeddedFieldName]
-                        ]
-                    );
+                    try {
+                        echo $this->requestAction(
+                            [
+                                'plugin' => $embeddedPlugin,
+                                'controller' => $embeddedController,
+                                'action' => $this->request->action
+                            ],
+                            [
+                                'query' => ['embedded' => $this->request->controller . '.' . $embeddedAssocName],
+                                'pass' => [$options['entity']->$embeddedFieldName]
+                            ]
+                        );
+                    } catch (RecordNotFoundException $e) {
+                        // just don't display anything if embedded record was not found
+                    }
                 }
             }
             $embeddedFields = [];


### PR DESCRIPTION
**Fixes following issues:**
* On edit View, if related record has been deleted, the relevant typeahead input displays its UUID instead of the display field value.
* On record view if a related module is embedded and its record has been deleted, a 404 error is shown.