### PR TITLE
Allow to predefine passed data for requestAction for add action

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -86,6 +86,11 @@ class AppController extends BaseController
     {
         $model = $this->{$this->name};
         $entity = $model->newEntity();
+
+        if (!empty($this->request->params['data'])) {
+            $this->request->data = $this->request->params['data'];
+        }
+
         if ($this->request->is('post')) {
             if ($this->request->data('btn_operation') == 'cancel') {
                 return $this->redirect(['action' => 'index']);


### PR DESCRIPTION
In case we call for `requestAction()` method, we can pass extra parameters that we don't need to input in the form.