### PR TITLE
Hiding excessive tabs with FileStorage

### DIFF
--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -112,6 +112,13 @@ class ViewViewTabsListener implements EventListenerInterface
 
             list($namespace, $class) = namespaceSplit(get_class($association));
 
+            // We hide from associations file_storage,
+            // as it's rendered within field handlers.
+            // No need for separate tab, except Documents module.
+            if ('Burzum/FileStorage.FileStorage' == $association->className() && 'Documents' != $this->_tableInstance->alias()) {
+                continue;
+            }
+
             $tab = [
                 'label' => $tabLabels[$association->alias()],
                 'alias' => $association->alias(),


### PR DESCRIPTION
FileStorage is related to Documents module. It's where wee need to view the list of files.
For other modules, the files rendered are shown with field handlers (files, images field handlers).