### PR TITLE
Field handler fixes

### DIFF
--- a/src/FieldHandlers/BaseCombinedFieldHandler.php
+++ b/src/FieldHandlers/BaseCombinedFieldHandler.php
@@ -54,14 +54,14 @@ abstract class BaseCombinedFieldHandler extends ListFieldHandler
             $options['label'] = null;
             $fieldName = $field . '_' . $suffix;
 
-            $data = $this->_getFieldValueFromData($fieldName, $data);
-            if (empty($data) && !empty($options['entity'])) {
-                $data = $this->_getFieldValueFromData($fieldName, $options['entity']);
+            $fieldData = $this->_getFieldValueFromData($fieldName, $data);
+            if (empty($fieldData) && !empty($options['entity'])) {
+                $fieldData = $this->_getFieldValueFromData($fieldName, $options['entity']);
             }
 
             $handler = new $preOptions['handler'];
 
-            $inputs[] = sprintf(static::INPUT_HTML, $handler->renderInput($table, $fieldName, $data, $options));
+            $inputs[] = sprintf(static::INPUT_HTML, $handler->renderInput($table, $fieldName, $fieldData, $options));
         }
 
         return sprintf(static::WRAPPER_HTML, $label, implode('', $inputs));
@@ -75,12 +75,12 @@ abstract class BaseCombinedFieldHandler extends ListFieldHandler
         $result = [];
         foreach ($this->_fields as $suffix => $fieldOptions) {
             $fieldName = $field . '_' . $suffix;
-            $data = $this->_getFieldValueFromData($fieldName, $data);
-            if (empty($data) && !empty($options['entity'])) {
-                $data = $this->_getFieldValueFromData($fieldName, $options['entity']);
+            $fieldData = $this->_getFieldValueFromData($fieldName, $data);
+            if (empty($fieldData) && !empty($options['entity'])) {
+                $fieldData = $this->_getFieldValueFromData($fieldName, $options['entity']);
             }
             $handler = new $fieldOptions['handler'];
-            $result[] = $handler->renderValue($table, $fieldName, $data, $options);
+            $result[] = $handler->renderValue($table, $fieldName, $fieldData, $options);
         }
 
         $result = implode('&nbsp;', $result);

--- a/src/FieldHandlers/BaseCombinedFieldHandler.php
+++ b/src/FieldHandlers/BaseCombinedFieldHandler.php
@@ -54,9 +54,9 @@ abstract class BaseCombinedFieldHandler extends ListFieldHandler
             $options['label'] = null;
             $fieldName = $field . '_' . $suffix;
 
-            $data = '';
-            if (isset($options['entity'])) {
-                $data = $options['entity']->{$fieldName};
+            $data = $this->_getFieldValueFromData($fieldName, $data);
+            if (empty($data) && !empty($options['entity'])) {
+               $data = $this->_getFieldValueFromData($fieldName, $options['entity']);
             }
 
             $handler = new $preOptions['handler'];
@@ -75,8 +75,9 @@ abstract class BaseCombinedFieldHandler extends ListFieldHandler
         $result = [];
         foreach ($this->_fields as $suffix => $fieldOptions) {
             $fieldName = $field . '_' . $suffix;
-            if (isset($options['entity'])) {
-                $data = $options['entity']->{$fieldName};
+            $data = $this->_getFieldValueFromData($fieldName, $data);
+            if (empty($data) && !empty($options['entity'])) {
+               $data = $this->_getFieldValueFromData($fieldName, $options['entity']);
             }
             $handler = new $fieldOptions['handler'];
             $result[] = $handler->renderValue($table, $fieldName, $data, $options);

--- a/src/FieldHandlers/BaseCombinedFieldHandler.php
+++ b/src/FieldHandlers/BaseCombinedFieldHandler.php
@@ -56,7 +56,7 @@ abstract class BaseCombinedFieldHandler extends ListFieldHandler
 
             $data = $this->_getFieldValueFromData($fieldName, $data);
             if (empty($data) && !empty($options['entity'])) {
-               $data = $this->_getFieldValueFromData($fieldName, $options['entity']);
+                $data = $this->_getFieldValueFromData($fieldName, $options['entity']);
             }
 
             $handler = new $preOptions['handler'];
@@ -77,7 +77,7 @@ abstract class BaseCombinedFieldHandler extends ListFieldHandler
             $fieldName = $field . '_' . $suffix;
             $data = $this->_getFieldValueFromData($fieldName, $data);
             if (empty($data) && !empty($options['entity'])) {
-               $data = $this->_getFieldValueFromData($fieldName, $options['entity']);
+                $data = $this->_getFieldValueFromData($fieldName, $options['entity']);
             }
             $handler = new $fieldOptions['handler'];
             $result[] = $handler->renderValue($table, $fieldName, $data, $options);

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -2,6 +2,8 @@
 namespace CsvMigrations\FieldHandlers;
 
 use Cake\Core\App;
+use Cake\Network\Request;
+use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use CsvMigrations\FieldHandlers\CsvField;
@@ -225,6 +227,7 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $fieldType = $options['fieldDefinitions']->getType();
 
         if (in_array($fieldType, array_keys($this->_fieldTypes))) {
@@ -265,7 +268,7 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
-        $result = $data;
+        $result = $this->_getFieldValueFromData($field, $data);
 
         return $result;
     }
@@ -314,6 +317,39 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
     public function getSearchLabel($field)
     {
         return Inflector::humanize($field);
+    }
+
+    /**
+     * Get field value from given data
+     *
+     * Extract field value from the variable, based on the type
+     * of the variable.  Support types are:
+     *
+     * * Entity, use Entity property with the field name
+     * * Request, use Request->data() with the key of the field name
+     * * Otherwise assume the variable is the data already
+     *
+     * @param string $field Field name
+     * @param Entity|Request|mixed $var Variable to extract value from
+     * @return mixed
+     */
+    protected function _getFieldValueFromData($field, $data)
+    {
+        $result = $data;
+
+        if ($data instanceof Entity) {
+            $result = $data->foo;
+
+            return $result;
+        }
+
+        if ($data instanceof Request) {
+            $result = isset($data->data[$field]) ? $data->data[$field] : null;
+
+            return $result;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -338,7 +338,7 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
         $result = $data;
 
         if ($data instanceof Entity) {
-            $result = $data->foo;
+            $result = $data->$field;
 
             return $result;
         }

--- a/src/FieldHandlers/BaseFileFieldHandler.php
+++ b/src/FieldHandlers/BaseFileFieldHandler.php
@@ -83,6 +83,7 @@ class BaseFileFieldHandler extends RelatedFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $relatedProperties = $this->_getRelatedProperties($options['fieldDefinitions']->getLimit(), $data);
 
         $fieldName = $this->_getFieldName($table, $field, $options);

--- a/src/FieldHandlers/BlobFieldHandler.php
+++ b/src/FieldHandlers/BlobFieldHandler.php
@@ -29,6 +29,7 @@ class BlobFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         if (is_resource($data)) {
             $data = stream_get_contents($data);
         }
@@ -49,6 +50,7 @@ class BlobFieldHandler extends BaseFieldHandler
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $result = $data;
         if (is_resource($data)) {
             $result = stream_get_contents($data);

--- a/src/FieldHandlers/BooleanFieldHandler.php
+++ b/src/FieldHandlers/BooleanFieldHandler.php
@@ -26,6 +26,7 @@ class BooleanFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         return $this->cakeView->Form->input($this->_getFieldName($table, $field, $options), [
             'type' => static::INPUT_FIELD_TYPE,
             'required' => (bool)$options['fieldDefinitions']->getRequired(),
@@ -44,6 +45,7 @@ class BooleanFieldHandler extends BaseFieldHandler
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $result = $data ? __('Yes') : __('No');
 
         return $result;

--- a/src/FieldHandlers/BooleanFieldHandler.php
+++ b/src/FieldHandlers/BooleanFieldHandler.php
@@ -27,6 +27,7 @@ class BooleanFieldHandler extends BaseFieldHandler
     public function renderInput($table, $field, $data = '', array $options = [])
     {
         $data = $this->_getFieldValueFromData($field, $data);
+
         return $this->cakeView->Form->input($this->_getFieldName($table, $field, $options), [
             'type' => static::INPUT_FIELD_TYPE,
             'required' => (bool)$options['fieldDefinitions']->getRequired(),

--- a/src/FieldHandlers/DateFieldHandler.php
+++ b/src/FieldHandlers/DateFieldHandler.php
@@ -32,6 +32,7 @@ class DateFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         if ($data instanceof Date) {
             $data = $data->i18nFormat(static::DATE_FORMAT);
         }
@@ -76,6 +77,7 @@ class DateFieldHandler extends BaseFieldHandler
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         if (is_object($data)) {
             $result = $data->i18nFormat(static::DATE_FORMAT);
         } else {

--- a/src/FieldHandlers/DatetimeFieldHandler.php
+++ b/src/FieldHandlers/DatetimeFieldHandler.php
@@ -32,6 +32,7 @@ class DatetimeFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         if ($data instanceof Time) {
             $data = $data->i18nFormat(static::DATETIME_FORMAT);
         }
@@ -76,6 +77,7 @@ class DatetimeFieldHandler extends BaseFieldHandler
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         if (is_object($data)) {
             $result = $data->i18nFormat(static::DATETIME_FORMAT);
         } else {

--- a/src/FieldHandlers/DblistFieldHandler.php
+++ b/src/FieldHandlers/DblistFieldHandler.php
@@ -32,6 +32,7 @@ class DblistFieldHandler extends BaseFieldHandler
     public function renderInput($table, $field, $data = '', array $options = [])
     {
         $result = '';
+        $data = $this->_getFieldValueFromData($field, $data);
         //CsvField object is mandatory
         if (!isset($options['fieldDefinitions']) ||
             !($options['fieldDefinitions'] instanceof CsvField)) {
@@ -62,6 +63,7 @@ class DblistFieldHandler extends BaseFieldHandler
     public function renderValue($table, $field, $data, array $options = [])
     {
         $result = '';
+        $data = $this->_getFieldValueFromData($field, $data);
 
         //CsvField object is mandatory
         if (!isset($options['fieldDefinitions']) ||

--- a/src/FieldHandlers/DecimalFieldHandler.php
+++ b/src/FieldHandlers/DecimalFieldHandler.php
@@ -16,6 +16,7 @@ class DecimalFieldHandler extends BaseFieldHandler
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $result = (float)filter_var($data, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
 
         $args = $this->_getDbColumnArgs($table, $field);
@@ -36,6 +37,7 @@ class DecimalFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $fieldType = $options['fieldDefinitions']->getType();
 
         if (in_array($fieldType, array_keys($this->_fieldTypes))) {

--- a/src/FieldHandlers/FileFieldHandler.php
+++ b/src/FieldHandlers/FileFieldHandler.php
@@ -27,11 +27,14 @@ class FileFieldHandler extends BaseFileFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
-        $entity = Hash::get($options, 'entity');
-        if (empty($entity)) {
+        $data = $this->_getFieldValueFromData($field, $data);
+        if (empty($data) && !empty($options['entity'])) {
+            $data = $this->_getFieldValueFromData('id', $options['entity']);
+        }
+        if (empty($data)) {
             $result = $this->_renderInputWithoutData($table, $field, $options);
         } else {
-            $result = $this->_renderInputWithData($table, $field, $options);
+            $result = $this->_renderInputWithData($table, $field, $data, $options);
         }
 
         return $result;
@@ -62,14 +65,13 @@ class FileFieldHandler extends BaseFileFieldHandler
      * @param  Table $table Table
      * @param  string $field Field
      * @param  array $options Options
+     * @param  mixed $data Data
      * @return string HTML input field with data attribute.
      */
-    protected function _renderInputWithData($table, $field, $options)
+    protected function _renderInputWithData($table, $field, $data, $options)
     {
         $fileUploadsUtils = new FileUploadsUtils($table);
-        $entity = Hash::get($options, 'entity');
-
-        $entities = $fileUploadsUtils->getFiles($entity->get('id'));
+        $entities = $fileUploadsUtils->getFiles($data);
 
         if (is_null($entities)) {
             return $this->_renderInputWithoutData($table, $field, $options);
@@ -87,7 +89,7 @@ class FileFieldHandler extends BaseFileFieldHandler
             $this->_getFieldName($table, $field, $options) . '[]',
             [
                 'multiple' => true,
-                'data-document-id' => $entity->get('id'),
+                'data-document-id' => $data,
                 'data-files' => json_encode($files),
             ]
         );
@@ -101,7 +103,10 @@ class FileFieldHandler extends BaseFileFieldHandler
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
-        $data = $options['entity']['id'];
+        $data = $this->_getFieldValueFromData($field, $data);
+        if (empty($data) && !empty($options['entity'])) {
+            $data = $this->_getFieldValueFromData('id', $options['entity']);
+        }
 
         return parent::renderValue($table, $field, $data, $options);
     }

--- a/src/FieldHandlers/HasManyFieldHandler.php
+++ b/src/FieldHandlers/HasManyFieldHandler.php
@@ -46,6 +46,7 @@ class HasManyFieldHandler extends RelatedFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $relatedProperties = $this->_getRelatedProperties($options['fieldDefinitions']->getLimit(), $data);
 
         if (!empty($relatedProperties['dispFieldVal']) && !empty($relatedProperties['config']['parent']['module'])) {

--- a/src/FieldHandlers/ListFieldHandler.php
+++ b/src/FieldHandlers/ListFieldHandler.php
@@ -31,6 +31,7 @@ class ListFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $fieldOptions = $this->_getSelectOptions($options['fieldDefinitions']->getLimit());
 
         $input = $this->_fieldToLabel($field, $options);
@@ -56,6 +57,7 @@ class ListFieldHandler extends BaseFieldHandler
     public function renderValue($table, $field, $data, array $options = [])
     {
         $result = '';
+        $data = $this->_getFieldValueFromData($field, $data);
 
         if (empty($data)) {
             return $result;

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -67,6 +67,7 @@ class RelatedFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $relatedProperties = $this->_getRelatedProperties($options['fieldDefinitions']->getLimit(), $data);
 
         if (!empty($relatedProperties['dispFieldVal']) && !empty($relatedProperties['config']['parent']['module'])) {
@@ -138,6 +139,7 @@ class RelatedFieldHandler extends BaseFieldHandler
     public function renderValue($table, $field, $data, array $options = [])
     {
         $result = null;
+        $data = $this->_getFieldValueFromData($field, $data);
 
         if (empty($data)) {
             return $result;

--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -7,6 +7,7 @@ use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Cake\View\Helper\IdGeneratorTrait;
 use CsvMigrations\FieldHandlers\BaseFieldHandler;
+use CsvMigrations\FieldHandlers\RelatedFieldHandler;
 
 trait RelatedFieldTrait
 {
@@ -78,9 +79,15 @@ trait RelatedFieldTrait
         $result['entity'] = $this->_getAssociatedRecord($table, $data);
         // get related table's displayField value
         if (!empty($result['entity'])) {
-            $result['dispFieldVal'] = !empty($result['entity']->{$result['displayField']})
-                ? $result['entity']->{$table->displayField()}
-                : null;
+            // Pass the value through related field handler
+            // to properly display the user-friendly label.
+            $fhf = new FieldHandlerFactory($this->cakeView);
+            $result['dispFieldVal'] = $fhf->renderValue(
+                $table,
+                $table->displayField(),
+                $result['entity']->{$table->displayField()},
+                ['renderAs' => RelatedFieldHandler::RENDER_PLAIN_VALUE]
+            );
         } else {
             $result['dispFieldVal'] = null;
         }

--- a/src/FieldHandlers/SublistFieldHandler.php
+++ b/src/FieldHandlers/SublistFieldHandler.php
@@ -21,6 +21,7 @@ class SublistFieldHandler extends ListFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         $fieldOptions = $this->_getSelectOptions($options['fieldDefinitions']->getLimit(), null, false);
         $optionValues = $this->_getSelectOptions($options['fieldDefinitions']->getLimit(), '');
         $structure = $this->_dynamicSelectStructure($fieldOptions);

--- a/src/FieldHandlers/TimeFieldHandler.php
+++ b/src/FieldHandlers/TimeFieldHandler.php
@@ -32,6 +32,7 @@ class TimeFieldHandler extends BaseFieldHandler
      */
     public function renderInput($table, $field, $data = '', array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         if ($data instanceof Time) {
             $data = $data->i18nFormat(static::TIME_FORMAT);
         }
@@ -76,6 +77,7 @@ class TimeFieldHandler extends BaseFieldHandler
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
+        $data = $this->_getFieldValueFromData($field, $data);
         if (is_object($data)) {
             $result = $data->i18nFormat(static::TIME_FORMAT);
         } else {

--- a/src/Template/Element/View/add.ctp
+++ b/src/Template/Element/View/add.ctp
@@ -106,7 +106,7 @@ $formOptions['type'] = 'file';
                                 }
 
                                 $handlerOptions = [
-                                    'entity' => (object)$this->request->data
+                                    'entity' => $this->request
                                 ];
 
                                 if ($embeddedDirty) {


### PR DESCRIPTION
A variety of small fixes around the field handlers.  Most noticeable:

* Improve the handling of the `$data` parameter in field handlers (figure things out from the type of the variable).
* Improve the handling of the `$options['entity']` parameter, especially when it is not an Entity instance.
* Improve display value in Related Field Handler, including the API and UI, like the select drop-downs.  The lookup is now recursive and is done properly through the field handlers, bringing more consistency.