### PR TITLE
Bugfix for select2 values missing parent module (task #3247)

### DIFF
--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -3,13 +3,11 @@ namespace CsvMigrations\Controller\Api;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Datasource\ResultSetDecorator;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Crud\Controller\ControllerTrait;
 use CsvMigrations\CsvMigrationsUtils;
-use CsvMigrations\FieldHandlers\RelatedFieldTrait;
 use CsvMigrations\FileUploadsUtils;
 use CsvMigrations\Panel;
 use CsvMigrations\PanelUtilTrait;
@@ -19,7 +17,6 @@ class AppController extends Controller
 {
     use ControllerTrait;
     use PanelUtilTrait;
-    use RelatedFieldTrait;
 
     public $components = [
         'RequestHandler',
@@ -339,32 +336,6 @@ class AppController extends Controller
 
         return $this->Crud->execute();
     }
-
-    /**
-     * Prepend parent module display field value to resultset.
-     *
-     * @param  \Cake\Datasource\ResultSetDecorator $entities Entities
-     * @return array
-     */
-    protected function _prependParentModule(ResultSetDecorator $entities)
-    {
-        $result = $entities->toArray();
-
-        foreach ($result as $id => &$value) {
-            $parentProperties = $this->_getRelatedParentProperties(
-                $this->_getRelatedProperties($this->{$this->name}->registryAlias(), $id)
-            );
-            if (!empty($parentProperties['dispFieldVal'])) {
-                $value = implode(' ' . $this->_separator . ' ', [
-                    $parentProperties['dispFieldVal'],
-                    $value
-                ]);
-            }
-        }
-
-        return $result;
-    }
-
 
     /**
      * Panels to show.

--- a/src/FieldHandlers/BaseCombinedFieldHandler.php
+++ b/src/FieldHandlers/BaseCombinedFieldHandler.php
@@ -76,6 +76,10 @@ abstract class BaseCombinedFieldHandler extends ListFieldHandler
         foreach ($this->_fields as $suffix => $fieldOptions) {
             $fieldName = $field . '_' . $suffix;
             $fieldData = $this->_getFieldValueFromData($fieldName, $data);
+            // fieldData will most probably be empty when dealing with combined fields for
+            // example, field 'salary' will have no data since is converted to 'salary_amount'
+            // and 'salary_currency'. In these cases we just re-call _getFeildValueFromData
+            // method and we pass to it the whole entity.
             if (empty($fieldData) && !empty($options['entity'])) {
                 $fieldData = $this->_getFieldValueFromData($fieldName, $options['entity']);
             }

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -19,6 +19,11 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
     const DB_FIELD_TYPE = 'string';
 
     /**
+     * Flag for rendering value as is
+     */
+    const RENDER_PLAIN_VALUE = 'plain';
+
+    /**
      * View instance.
      *
      * @var \Cake\View\View

--- a/src/FieldHandlers/EmailFieldHandler.php
+++ b/src/FieldHandlers/EmailFieldHandler.php
@@ -20,6 +20,9 @@ class EmailFieldHandler extends BaseFieldHandler
 
         // Only link to valid emails, to avoid unpredictable behavior
         if (!empty($result) && filter_var($result, FILTER_VALIDATE_EMAIL)) {
+            if (isset($options['renderAs']) && $options['renderAs'] === static::RENDER_PLAIN_VALUE) {
+                return $result;
+            }
             $result = $this->cakeView->Html->link($result, 'mailto:' . $result, ['target' => '_blank']);
         }
 

--- a/src/FieldHandlers/EmailFieldHandler.php
+++ b/src/FieldHandlers/EmailFieldHandler.php
@@ -20,10 +20,9 @@ class EmailFieldHandler extends BaseFieldHandler
 
         // Only link to valid emails, to avoid unpredictable behavior
         if (!empty($result) && filter_var($result, FILTER_VALIDATE_EMAIL)) {
-            if (isset($options['renderAs']) && $options['renderAs'] === static::RENDER_PLAIN_VALUE) {
-                return $result;
+            if (!isset($options['renderAs']) || !$options['renderAs'] === static::RENDER_PLAIN_VALUE) {
+                $result = $this->cakeView->Html->link($result, 'mailto:' . $result, ['target' => '_blank']);
             }
-            $result = $this->cakeView->Html->link($result, 'mailto:' . $result, ['target' => '_blank']);
         }
 
         return $result;

--- a/src/FieldHandlers/FileFieldHandler.php
+++ b/src/FieldHandlers/FileFieldHandler.php
@@ -5,6 +5,9 @@ use Cake\Utility\Hash;
 use CsvMigrations\FieldHandlers\BaseFileFieldHandler;
 use CsvMigrations\FileUploadsUtils;
 
+/**
+ * @deprecated 10.0.0 Obsolete class since new File Uploads implementation
+ */
 class FileFieldHandler extends BaseFileFieldHandler
 {
     /**

--- a/src/FieldHandlers/ListFieldHandler.php
+++ b/src/FieldHandlers/ListFieldHandler.php
@@ -78,7 +78,11 @@ class ListFieldHandler extends BaseFieldHandler
                 }
             }
         } else {
-            $result = sprintf(static::VALUE_NOT_FOUND_HTML, $data);
+            if (isset($options['renderAs']) && $options['renderAs'] === static::RENDER_PLAIN_VALUE) {
+                $result = $data;
+            } else {
+                $result = sprintf(static::VALUE_NOT_FOUND_HTML, $data);
+            }
         }
 
         return $result;

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -154,6 +154,7 @@ class RelatedFieldHandler extends BaseFieldHandler
             if (empty($properties)) {
                 continue;
             }
+
             if (isset($options['renderAs']) && $options['renderAs'] === static::RENDER_PLAIN_VALUE) {
                 $inputs[] = h($properties['dispFieldVal']);
             } else {

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -29,11 +29,6 @@ class RelatedFieldHandler extends BaseFieldHandler
     const LABEL_FIELD_SUFFIX = '_label';
 
     /**
-     * Flag for rendering value without url
-     */
-    const RENDER_PLAIN_VALUE = 'plain';
-
-    /**
      * Html input wrapper markup
      */
     const HTML_INPUT_WRAPPER = '<div class="form-group%s">%s%s</div>';

--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -81,7 +81,7 @@ trait RelatedFieldTrait
         if (!empty($result['entity'])) {
             // Pass the value through related field handler
             // to properly display the user-friendly label.
-            $fhf = new FieldHandlerFactory($this->cakeView);
+            $fhf = new FieldHandlerFactory();
             $result['dispFieldVal'] = $fhf->renderValue(
                 $table,
                 $table->displayField(),

--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -16,7 +16,7 @@ trait RelatedFieldTrait
      *
      * @var string
      */
-    protected $_separator = '&gt;';
+    protected $_separator = '»';
 
     /**
      * Get related model's parent model properties.

--- a/src/FieldHandlers/TextFieldHandler.php
+++ b/src/FieldHandlers/TextFieldHandler.php
@@ -38,7 +38,9 @@ class TextFieldHandler extends BaseFieldHandler
         $result = filter_var($data, FILTER_SANITIZE_STRING);
 
         if (!empty($result)) {
-            $result = $this->cakeView->Text->autoParagraph($result);
+            if (!isset($options['renderAs']) || !$options['renderAs'] === static::RENDER_PLAIN_VALUE) {
+                $result = $this->cakeView->Text->autoParagraph($result);
+            }
         }
 
         return $result;

--- a/src/FieldHandlers/UrlFieldHandler.php
+++ b/src/FieldHandlers/UrlFieldHandler.php
@@ -20,7 +20,9 @@ class UrlFieldHandler extends BaseFieldHandler
 
         // Only link to URLs with schema, to avoid unpredictable behavior
         if (!empty($result) && filter_var($result, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED)) {
-            $result = $this->cakeView->Html->link($result, $result, ['target' => '_blank']);
+            if (!isset($options['renderAs']) || !$options['renderAs'] === static::RENDER_PLAIN_VALUE) {
+                $result = $this->cakeView->Html->link($result, $result, ['target' => '_blank']);
+            }
         }
 
         return $result;

--- a/tests/TestCase/FieldHandlers/EmailFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/EmailFieldHandlerTest.php
@@ -44,4 +44,10 @@ class EmailFieldHandlerTest extends PHPUnit_Framework_TestCase
         $result = $this->fh->renderValue(null, null, $value, []);
         $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
     }
+
+    public function testRenderValueWithPlainFlag()
+    {
+        $result = $this->fh->renderValue(null, null, 'john.smith@company.com', ['renderAs' => 'plain']);
+        $this->assertEquals('john.smith@company.com', $result);
+    }
 }

--- a/tests/TestCase/FieldHandlers/TextFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/TextFieldHandlerTest.php
@@ -43,4 +43,10 @@ class TextFieldHandlerTest extends PHPUnit_Framework_TestCase
         $result = $this->fh->renderValue(null, null, $value, []);
         $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
     }
+
+    public function testRenderValueWithPlainFlag()
+    {
+        $result = $this->fh->renderValue(null, null, 'Hello World!', ['renderAs' => 'plain']);
+        $this->assertEquals('Hello World!', $result);
+    }
 }

--- a/tests/TestCase/FieldHandlers/UrlFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/UrlFieldHandlerTest.php
@@ -45,4 +45,10 @@ class UrlFieldHandlerTest extends PHPUnit_Framework_TestCase
         $result = $this->fh->renderValue(null, null, $value, []);
         $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
     }
+
+    public function testRenderValueWithPlainFlag()
+    {
+        $result = $this->fh->renderValue(null, null, 'http://www.google.com', ['renderAs' => 'plain']);
+        $this->assertEquals('http://www.google.com', $result);
+    }
 }


### PR DESCRIPTION
**Additionally:**

- Added support for `renderAs = plain` flag to field handlers that require it
- Deprecated doc block
- Explanatory doc block