### PR TITLE
make timepicker not showing current time

### DIFF
--- a/webroot/js/timepicker.init.js
+++ b/webroot/js/timepicker.init.js
@@ -30,7 +30,8 @@
             // time picker
             $('[data-provide="timepicker"]').timepicker({
                 showMeridian: false,
-                minuteStep: 5
+                minuteStep: 5,
+                defaultTime: false
             });
         }
     };


### PR DESCRIPTION
We use timepicker for duration as well, thus meetings/tasks might have duration of current time (aka 10:30 = 10.5 hrs meeting/task) which is incorrect.