### PR TITLE
Show popup picker at the bottom of the element

### DIFF
--- a/webroot/js/datetimepicker.init.js
+++ b/webroot/js/datetimepicker.init.js
@@ -32,7 +32,7 @@
                 singleDatePicker: true,
                 showDropdowns: true,
                 timePicker: true,
-                drops: "up",
+                drops: "down",
                 timePicker12Hour: false,
                 timePickerIncrement: 5,
                 format: "YYYY-MM-DD HH:mm"


### PR DESCRIPTION
When the form is vertically short we get a bug with the popup daterangepicker as the year/month header gets hidden with the negative margin-top. For a quick solution, the popup is moved underneath the element  to show fully dates/years/months.