### PR TITLE
adding seconds to fix entity patching

### DIFF
--- a/webroot/js/datetimepicker.init.js
+++ b/webroot/js/datetimepicker.init.js
@@ -35,7 +35,7 @@
                 drops: "down",
                 timePicker12Hour: false,
                 timePickerIncrement: 5,
-                format: "YYYY-MM-DD HH:mm"
+                format: "YYYY-MM-DD HH:mm:ss"
             });
         }
     };


### PR DESCRIPTION
patchingEntity method is passing object as a string if we don't define seconds in the format.