### PR TITLE
Lookup results sorting (task #3285)

### DIFF
--- a/src/Events/LookupListener.php
+++ b/src/Events/LookupListener.php
@@ -40,11 +40,11 @@ class LookupListener extends BaseViewListener
 
         $fields = $this->_getTypeaheadFields($table);
 
-        if (empty($fields)) {
-            throw new RuntimeException("No typeahead or display field configured for " . $table->alias());
-        }
-
         $query->order($this->_getOrderByFields($table, $query, $fields));
+
+        if (empty($fields)) {
+            return;
+        }
 
         if (!$request->query('query')) {
             return;


### PR DESCRIPTION
Sorting of lookup results is now applied on the actual query before is run. The sorting is applied by the module's typeahead fields, and if there is a parent module then its display field takes precedence over the module's typeahead fields.

For example, if a module has typeahead fields `['name', 'type']` then these will be used for sorting the results. If it has a parent module with display field 'title', then the sorting order will change to `['title', 'name', 'type']`.