### PR TITLE
Associated files in API responses (task #3299)

### DIFF
--- a/src/Events/BaseViewListener.php
+++ b/src/Events/BaseViewListener.php
@@ -25,6 +25,11 @@ abstract class BaseViewListener implements EventListenerInterface
     use PrettifyTrait;
 
     /**
+     * Pretty format identifier
+     */
+    const FORMAT_PRETTY = 'pretty';
+
+    /**
      * Datatables format identifier
      */
     const FORMAT_DATATABLES = 'datatables';

--- a/src/Events/BaseViewListener.php
+++ b/src/Events/BaseViewListener.php
@@ -35,24 +35,16 @@ abstract class BaseViewListener implements EventListenerInterface
     const FORMAT_DATATABLES = 'datatables';
 
     /**
-     * Here we list forced associations when fetching record(s) associated data.
-     * This is useful, for example, when trying to fetch a record(s) associated
-     * documents (such as photos, pdfs etc), which are nested two levels deep.
-     *
-     * To detect these nested associations, since our association names
-     * are constructed dynamically, we use the associations class names
-     * as identifiers.
-     *
-     * @var array
+     * File association class name
      */
-    protected $_nestedAssociations = [];
+    const FILE_CLASS_NAME = 'Burzum/FileStorage.FileStorage';
 
     /**
-     * Nested association chain for retrieving associated file records
+     * Current module fields list which are associated with files
      *
      * @var array
      */
-    protected $_fileAssociations = ['Documents'];
+    protected $_fileAssociationFields = [];
 
     /**
      * Wrapper method that checks if Table instance has method 'findByLookupFields'
@@ -272,39 +264,22 @@ abstract class BaseViewListener implements EventListenerInterface
     }
 
     /**
-     * Method responsible for retrieving current Table's associations
+     * Method responsible for retrieving current Table's file associations
      *
-     * @param  Cake\Event\Event $event Event instance
+     * @param  Cake\ORM\Table $table Table instance
      * @return array
      */
-    protected function _getAssociations(Event $event)
+    protected function _getFileAssociations(Table $table)
     {
         $result = [];
 
-        $associations = $event->subject()->{$event->subject()->name}->associations();
+        foreach ($table->associations() as $association) {
+            if (static::FILE_CLASS_NAME !== $association->className()) {
+                continue;
+            }
 
-        if (empty($associations)) {
-            return $result;
+            $result[] = $association->name();
         }
-
-        // always include file associations
-        $result = $this->_containAssociations(
-            $associations,
-            $this->_fileAssociations,
-            true
-        );
-
-        if (!$event->subject()->request->query('associated')) {
-            return $result;
-        }
-
-        $result = array_merge(
-            $this->_containAssociations(
-                $associations,
-                $this->_nestedAssociations
-            ),
-            $result
-        );
 
         return $result;
     }

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -38,7 +38,12 @@ class IndexViewListener extends BaseViewListener
      */
     public function beforePaginate(Event $event, Query $query)
     {
-        $query->contain($this->_getAssociations($event));
+        $table = $event->subject()->{$event->subject()->name};
+        $request = $event->subject()->request;
+
+        if (!in_array($request->query('format'), [static::FORMAT_PRETTY, static::FORMAT_DATATABLES])) {
+            $query->contain($this->_getFileAssociations($table));
+        }
         $this->_filterByConditions($query, $event);
         $this->_selectActionFields($query, $event);
         $this->_handleDtSorting($query, $event);

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -22,11 +22,6 @@ class IndexViewListener extends BaseViewListener
     const MENU_PROPERTY_NAME = '_Menus';
 
     /**
-     * Pretty format identifier
-     */
-    const FORMAT_PRETTY = 'pretty';
-
-    /**
      * {@inheritDoc}
      */
     public function implementedEvents()

--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -58,16 +58,27 @@ class IndexViewListener extends BaseViewListener
             return;
         }
 
+        $table = $event->subject()->{$event->subject()->name};
+        $request = $event->subject()->request;
+
         foreach ($entities as $entity) {
             $this->_resourceToString($entity);
         }
 
-        // @todo temporary functionality, please see _includeFiles() method documentation.
-        foreach ($entities as $entity) {
-            $this->_includeFiles($entity, $event);
-        }
+        if (in_array($request->query('format'), [static::FORMAT_PRETTY, static::FORMAT_DATATABLES])) {
+            $fields = [];
+            if (static::FORMAT_DATATABLES === $request->query('format')) {
+                $fields = $this->_getActionFields($event->subject()->request);
+            }
 
-        $this->_prettifyEntities($entities, $event);
+            foreach ($entities as $entity) {
+                $this->_prettify($entity, $table, $fields);
+            }
+        } else { // @todo temporary functionality, please see _includeFiles() method documentation.
+            foreach ($entities as $entity) {
+                $this->_restructureFiles($entity, $table);
+            }
+        }
         $this->_includeMenus($entities, $event);
     }
 
@@ -147,7 +158,7 @@ class IndexViewListener extends BaseViewListener
             return;
         }
 
-        $virtualFields = $event->subject()->{$event->subject()->name}->getVirtualFields();
+        $table = $event->subject()->{$event->subject()->name};
 
         $sortCol = $event->subject()->request->query('order.0.column') ?: 0;
 
@@ -166,48 +177,23 @@ class IndexViewListener extends BaseViewListener
             return;
         }
 
-        $sortCol = $fields[$sortCol];
-
-        $sortCols = [];
+        $sortCols = $fields[$sortCol];
         // handle virtual field
-        if (!empty($virtualFields) && isset($virtualFields[$sortCol])) {
-            $sortCols = $virtualFields[$sortCol];
-        } else {
-            $sortCols = (array)$sortCol;
+        $virtualFields = $table->getVirtualFields();
+        if (!empty($virtualFields) && isset($virtualFields[$sortCols])) {
+            $sortCols = $virtualFields[$sortCols];
         }
+        $sortCols = (array)$sortCols;
 
         // prefix table name
         foreach ($sortCols as &$v) {
-            $v = $event->subject()->name . '.' . $v;
+            $v = $table->aliasField($v);
         }
 
         // add sort direction to all columns
         $conditions = array_fill_keys($sortCols, $sortDir);
 
         $query->order($conditions);
-    }
-
-    /**
-     * Method that prepares entities to run through pretiffy logic.
-     *
-     * @param  \Cake\ORM\ResultSet $entities Entities
-     * @param  \Cake\Event\Event   $event    Event instance
-     * @return void
-     */
-    protected function _prettifyEntities(ResultSet $entities, Event $event)
-    {
-        if (!in_array($event->subject()->request->query('format'), [static::FORMAT_PRETTY, static::FORMAT_DATATABLES])) {
-            return;
-        }
-
-        $fields = [];
-        if (static::FORMAT_DATATABLES === $event->subject()->request->query('format')) {
-            $fields = $this->_getActionFields($event->subject()->request);
-        }
-
-        foreach ($entities as $entity) {
-            $this->_prettify($entity, $event->subject()->{$event->subject()->name}, $fields);
-        }
     }
 
     /**

--- a/src/Events/ViewViewListener.php
+++ b/src/Events/ViewViewListener.php
@@ -24,8 +24,14 @@ class ViewViewListener extends BaseViewListener
      */
     public function beforeFind(Event $event, Query $query)
     {
+        $table = $event->subject()->{$event->subject()->name};
+        $request = $event->subject()->request;
+
         $this->_lookupFields($query, $event);
-        $query->contain($this->_getAssociations($event));
+
+        if (static::FORMAT_PRETTY !== $request->query('format')) {
+            $query->contain($this->_getFileAssociations($table));
+        }
     }
 
     /**

--- a/src/Events/ViewViewListener.php
+++ b/src/Events/ViewViewListener.php
@@ -9,11 +9,6 @@ use CsvMigrations\Events\BaseViewListener;
 class ViewViewListener extends BaseViewListener
 {
     /**
-     * Pretty format identifier
-     */
-    const FORMAT_PRETTY = 'pretty';
-
-    /**
      * {@inheritDoc}
      */
     public function implementedEvents()

--- a/src/Events/ViewViewListener.php
+++ b/src/Events/ViewViewListener.php
@@ -2,8 +2,10 @@
 namespace CsvMigrations\Events;
 
 use Cake\Event\Event;
+use Cake\Network\Request;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
+use Cake\ORM\Table;
 use CsvMigrations\Events\BaseViewListener;
 
 class ViewViewListener extends BaseViewListener
@@ -39,29 +41,19 @@ class ViewViewListener extends BaseViewListener
      */
     public function afterFind(Event $event, Entity $entity)
     {
+        $table = $event->subject()->{$event->subject()->name};
+        $request = $event->subject()->request;
+
         $this->_resourceToString($entity);
-        // @todo temporary functionality, please see _includeFiles() method documentation.
-        $this->_includeFiles($entity, $event);
 
-        $this->_prettifyEntity($entity, $event);
-
-        $displayField = $event->subject()->{$event->subject()->name}->displayField();
-        $entity->{$displayField} = $entity->get($displayField);
-    }
-
-    /**
-     * Method that prepares entity to run through pretiffy logic.
-     *
-     * @param  \Cake\ORM\Entity  $entity Entity
-     * @param  \Cake\Event\Event $event  Event instance
-     * @return void
-     */
-    protected function _prettifyEntity(Entity $entity, Event $event)
-    {
-        if (!in_array($event->subject()->request->query('format'), [static::FORMAT_PRETTY])) {
-            return;
+        if (static::FORMAT_PRETTY === $request->query('format')) {
+            $this->_prettify($entity, $table, []);
+            // $this->_prettifyEntity($entity, $table, $request);
+        } else { // @todo temporary functionality, please see _includeFiles() method documentation.
+            $this->_restructureFiles($entity, $table);
         }
 
-        $this->_prettify($entity, $event->subject()->{$event->subject()->name}, []);
+        $displayField = $table->displayField();
+        $entity->{$displayField} = $entity->get($displayField);
     }
 }

--- a/src/PrettifyTrait.php
+++ b/src/PrettifyTrait.php
@@ -49,7 +49,8 @@ trait PrettifyTrait
                         continue;
                     }
 
-                    $tableName = $table->association($associatedEntity->source())->className();
+                    list(, $associationName) = pluginSplit($associatedEntity->source());
+                    $tableName = $table->association($associationName)->className();
                     $this->_prettify($associatedEntity, $tableName);
                 }
             }


### PR DESCRIPTION
**File associations**
The method that retrieves file associations, which later on are passed to the Query `contain()` method, have been refactored since the file associations are now flat.

**Dropped associations support**
Associations and nested associations support in API responses has now been dropped.

**Files restructure**
When associated files are added to the entity object they are stored in a property matching the association name. For example, if you have a `photos` field associated with the File Storage table, then the associated files will be added to the entity under a property named `photos_file_storage_file_storage`. With the file restructure logic the associated files are moved under the field name (in this case `photos`) and the association named property is removed.