### PR TITLE
PHPUnit 5 (task #3311)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "maiconpinto/cakephp-adminlte-theme": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "^5.0",
         "cakephp/cakephp-codesniffer": "dev-master"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "type": "cakephp-plugin",
     "license": "GPL-2.0",
     "require": {
-        "php": ">=5.4.16",
         "cakephp/cakephp": ">3.0.0 <4.0",
         "cakephp/migrations": "~1.0",
         "league/csv": "^8.1",


### PR DESCRIPTION
Limit PHPUnit version to 5, in order to avoid PHP 5/7 compatibility issues, introduced by PHPUnit 6.