### PR TITLE
Panel expression for null values

### DIFF
--- a/src/Panel.php
+++ b/src/Panel.php
@@ -161,7 +161,7 @@ class Panel
     {
         $result = [];
         foreach ($this->getFields() as $f) {
-            if (isset($data[$f])) {
+            if (array_key_exists($f, $data)) {
                 $result[$f] = $data[$f];
             }
         }


### PR DESCRIPTION
`isset()`  will return false for keys that are part of the array but their value is set to `null`. This is not the expected behaviour. Instead, we check if the key is set in the array (`array_key_exists()`) and then we add it to the result no matter what is its value.