### PR TITLE
Tabs listener performance fix

### DIFF
--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -162,7 +162,7 @@ class ViewViewTabsListener implements EventListenerInterface
         $labelCounts = [];
         // Gather labels for all associations
         foreach ($tableInstance->associations() as $association) {
-            $assocTableInstance = TableRegistry::get($association->table());
+            $assocTableInstance = $association->target();
 
             $icon = $this->_getTableIcon($assocTableInstance);
             $assocAlias = $association->alias();


### PR DESCRIPTION
Instead of fetching the associated table instance using TableRegistry class, we just grab it from the association class using the `target()` method.