### PR TITLE
Factory - renderName() added

### DIFF
--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -62,6 +62,23 @@ class FieldHandlerFactory
         return $handler->renderInput($data, $options);
     }
 
+
+    /**
+     * Render field form label
+     *
+     * @param  mixed  $table   name or instance of the Table
+     * @param  string $field   field name
+     * @param  array  $options field options
+     * @return string          field input
+     */
+    public function renderName($table, $field, array $options = [])
+    {
+        $table = $this->_getTableInstance($table);
+        $handler = $this->_getHandler($table, $field, $options);
+
+        return $handler->renderName();
+    }
+
     /**
      * Get search options
      *

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -76,6 +76,8 @@ class FieldHandlerFactory
         $table = $this->_getTableInstance($table);
         $handler = $this->_getHandler($table, $field, $options);
 
+        //@TODO: add options for the renderName instance methods,
+        //so we could customize the label.
         return $handler->renderName();
     }
 

--- a/src/Template/Element/View/index.ctp
+++ b/src/Template/Element/View/index.ctp
@@ -2,6 +2,9 @@
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Utility\Inflector;
+use CsvMigrations\FieldHandlers\FieldHandlerFactory;
+
+$fhf = new FieldHandlerFactory($this);
 
 // Setup Index View js logic
 echo $this->Html->css('AdminLTE./plugins/datatables/dataTables.bootstrap', ['block' => 'css']);
@@ -62,7 +65,22 @@ if (empty($options['title'])) {
                 <thead>
                     <tr>
                     <?php foreach ($options['fields'] as $field) : ?>
-                        <th><?= Inflector::humanize($field[0]['name']); ?></th>
+                    <?php
+
+                    $tableName = $field[0]['model'];
+                    if (!is_null($field[0]['plugin'])) {
+                        $tableName = $field[0]['plugin'] . '.' . $tableName;
+                    }
+                    $renderOptions = [];
+
+                    $label = $fhf->renderName(
+                        $tableName,
+                        $field[0]['name'],
+                        $renderOptions
+                    );
+
+                    ?>
+                        <th><?= $label ?></th>
                     <?php endforeach; ?>
                     <th><?= __('Actions'); ?></th>
                     </tr>

--- a/src/Template/Element/View/view.ctp
+++ b/src/Template/Element/View/view.ctp
@@ -101,11 +101,8 @@ if (empty($options['title'])) {
                         }
                         ?>
                         <?php if (!$embeddedDirty) : // non-embedded field ?>
-                            <div class="col-xs-4 col-md-2 text-right">
-                                <strong><?= Inflector::humanize($field['name']) ?>:</strong>
-                            </div>
-                            <div class="col-xs-8 col-md-4">
                             <?php
+
                             $tableName = $field['model'];
                             if (!is_null($field['plugin'])) {
                                 $tableName = $field['plugin'] . '.' . $tableName;
@@ -114,6 +111,19 @@ if (empty($options['title'])) {
                                 'entity' => $options['entity'],
                                 'imageSize' => 'small'
                             ];
+
+                            $label = $fhf->renderName(
+                                $tableName,
+                                $field['name'],
+                                $renderOptions
+                            );
+
+                            ?>
+                            <div class="col-xs-4 col-md-2 text-right">
+                                <strong><?= $label?>:</strong>
+                            </div>
+                            <div class="col-xs-8 col-md-4">
+                            <?php
                             $value = $fhf->renderValue(
                                 $tableName,
                                 $field['name'],

--- a/tests/TestCase/FieldHandlers/FieldHandlerFactoryTest.php
+++ b/tests/TestCase/FieldHandlers/FieldHandlerFactoryTest.php
@@ -101,6 +101,15 @@ class FieldHandlerFactoryTest extends TestCase
         $this->assertRegexp('/input/i', $result, "Rendering input for 'id' field has no 'input'");
     }
 
+
+    public function testRenderName()
+    {
+        $result = $this->fhf->renderName($this->table, 'testField');
+        $this->assertEquals('Test Field', $result);
+    }
+
+
+
     public function testRenderValue()
     {
         $result = $this->fhf->renderValue($this->table, 'id', 'blah');

--- a/tests/TestCase/FieldHandlers/FieldHandlerFactoryTest.php
+++ b/tests/TestCase/FieldHandlers/FieldHandlerFactoryTest.php
@@ -101,14 +101,11 @@ class FieldHandlerFactoryTest extends TestCase
         $this->assertRegexp('/input/i', $result, "Rendering input for 'id' field has no 'input'");
     }
 
-
     public function testRenderName()
     {
         $result = $this->fhf->renderName($this->table, 'testField');
         $this->assertEquals('Test Field', $result);
     }
-
-
 
     public function testRenderValue()
     {


### PR DESCRIPTION
In order to output same field names everywhere in the system, `renderName()` method added to fix label names to correlate with other field names.