### PR TITLE
Migration issue with fieldsToDb

### DIFF
--- a/src/CsvMigration.php
+++ b/src/CsvMigration.php
@@ -64,9 +64,9 @@ class CsvMigration extends AbstractMigration
     public function csv(Table $table, $path = '')
     {
         $this->_fhf = new FieldHandlerFactory();
+
         $this->_table = $table;
         $this->_handleCsv($path);
-
         return $this->_table;
     }
 
@@ -79,6 +79,7 @@ class CsvMigration extends AbstractMigration
     protected function _handleCsv($path = '')
     {
         $tableName = Inflector::pluralize(Inflector::classify($this->_table->getName()));
+
         if ('' === trim($path)) {
             $pathFinder = new MigrationPathFinder;
             $path = $pathFinder->find($tableName);
@@ -89,7 +90,6 @@ class CsvMigration extends AbstractMigration
         $csvData = array_merge($csvData, $this->_requiredFields);
 
         $tableFields = $this->_getTableFields();
-
         if (empty($tableFields)) {
             $this->_createFromCsv($csvData, $tableName);
         } else {
@@ -203,7 +203,7 @@ class CsvMigration extends AbstractMigration
     {
         foreach ($csvData as $col) {
             $csvField = new CsvField($col);
-            $dbFields = $this->_fhf->fieldToDb($csvField, $table);
+            $dbFields = $this->_fhf->fieldToDb($csvField, $table, ['name' => $csvField->getName(), 'type' => $csvField->getType()]);
 
             if (empty($dbFields)) {
                 continue;

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -128,8 +128,12 @@ class FieldHandlerFactory
         if (empty($field)) {
             $field = $csvField->getName();
         }
-
-        $table = $this->_getTableInstance($table);
+        try {
+            $table = $this->_getTableInstance($table);
+        } catch (\Exception $e) {
+            $table = new \Cake\ORM\Table();
+            echo $e->getMessage();
+        }
         $handler = $this->_getHandler($table, $field);
         $fields = $handler->fieldToDb($csvField);
 
@@ -189,7 +193,6 @@ class FieldHandlerFactory
         if (in_array($tableName, array_keys($this->_tableInstances))) {
             return $this->_tableInstances[$tableName];
         }
-
         // Populate cache
         $this->_tableInstances[$tableName] = TableRegistry::get($tableName);
 
@@ -264,7 +267,6 @@ class FieldHandlerFactory
         if (empty($fieldDefinitions[$fieldName])) {
             throw new \RuntimeException("Failed to get definition for field '$fieldName'");
         }
-
         $field = new CsvField($fieldDefinitions[$fieldName]);
         $fieldType = $field->getType();
 


### PR DESCRIPTION
When the migration is first hit by `cake migrations migrate`, method `createFromCsv` method
tries to instantiate TableRegistry of the table that hasn't been created.

We should instantiate the FieldHandler object from the Factory that stores the settings on the specific field type, and convert it to Db field without instantiating the table.

Current proof of concept does create a table but throws a lot of exceptions on the `fieldToDb` method:

```
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.tablename' doesn't exist
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.tablename' doesn't exist
```