### PR TITLE
Switched `fieldToDb()` method to be static

### DIFF
--- a/src/CsvMigration.php
+++ b/src/CsvMigration.php
@@ -218,9 +218,9 @@ class CsvMigration extends AbstractMigration
     /**
      * Update (modify/delete) table fields in comparison to the CSV data
      *
-     * @param  array  $csvData    CSV data
-     * @param  string $table      Table name
-     * @param  array  $tableField Existing table fields
+     * @param  array  $csvData     CSV data
+     * @param  string $table       Table name
+     * @param  array  $tableFields Existing table fields
      * @return void
      */
     protected function _updateFromCsv(array $csvData, $table, array $tableFields)

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -402,13 +402,13 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
      * @return array                                           DbField instances
      */
-    public function fieldToDb(CsvField $csvField)
+    public static function fieldToDb(CsvField $csvField)
     {
         $csvField->setType(static::DB_FIELD_TYPE);
 
         $dbField = DbField::fromCsvField($csvField);
         $result = [
-            $this->field => $dbField,
+            $csvField->getName() => $dbField,
         ];
 
         return $result;

--- a/src/FieldHandlers/BaseListFieldHandler.php
+++ b/src/FieldHandlers/BaseListFieldHandler.php
@@ -37,14 +37,14 @@ abstract class BaseListFieldHandler extends BaseFieldHandler
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
      * @return array                                           DbField instances
      */
-    public function fieldToDb(CsvField $csvField)
+    public static function fieldToDb(CsvField $csvField)
     {
         $csvField->setType(static::DB_FIELD_TYPE);
         $csvField->setLimit(null);
 
         $dbField = DbField::fromCsvField($csvField);
         $result = [
-            $this->field => $dbField,
+            $csvField->getName() => $dbField,
         ];
 
         return $result;

--- a/src/FieldHandlers/BaseRelatedFieldHandler.php
+++ b/src/FieldHandlers/BaseRelatedFieldHandler.php
@@ -297,14 +297,14 @@ abstract class BaseRelatedFieldHandler extends BaseFieldHandler
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
      * @return array                                           DbField instances
      */
-    public function fieldToDb(CsvField $csvField)
+    public static function fieldToDb(CsvField $csvField)
     {
         $csvField->setType(static::DB_FIELD_TYPE);
         $csvField->setLimit(null);
 
         $dbField = DbField::fromCsvField($csvField);
         $result = [
-            $this->field => $dbField,
+            $csvField->getName() => $dbField,
         ];
 
         return $result;

--- a/src/FieldHandlers/BlobFieldHandler.php
+++ b/src/FieldHandlers/BlobFieldHandler.php
@@ -26,7 +26,7 @@ class BlobFieldHandler extends BaseSimpleFieldHandler
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
      * @return array                                           DbField instances
      */
-    public function fieldToDb(CsvField $csvField)
+    public static function fieldToDb(CsvField $csvField)
     {
         $csvField->setType(self::DB_FIELD_TYPE);
         // Set the limit to Phinx\Db\Adapter\MysqlAdapter::BLOB_LONG
@@ -34,7 +34,7 @@ class BlobFieldHandler extends BaseSimpleFieldHandler
 
         $dbField = DbField::fromCsvField($csvField);
         $result = [
-            $this->field => $dbField,
+            $csvField->getName() => $dbField,
         ];
 
         return $result;

--- a/src/FieldHandlers/CsvField.php
+++ b/src/FieldHandlers/CsvField.php
@@ -291,7 +291,7 @@ class CsvField
         }
 
         if (is_int($limit) || is_numeric($limit)) {
-            $result = abs((int)$limit);
+            $result = abs($limit);
             if ($result == 0) {
                 $result = null;
             }

--- a/src/FieldHandlers/DbField.php
+++ b/src/FieldHandlers/DbField.php
@@ -87,7 +87,7 @@ class DbField
     /**
      * Construct a new instance from CsvField
      *
-     * @param CsvField $CsvField CsvField instance
+     * @param CsvField $csvField CsvField instance
      * @return DbField
      */
     public static function fromCsvField(CsvField $csvField)

--- a/src/FieldHandlers/DecimalFieldHandler.php
+++ b/src/FieldHandlers/DecimalFieldHandler.php
@@ -56,7 +56,7 @@ class DecimalFieldHandler extends BaseNumberFieldHandler
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
      * @return array                                           DbField instances
      */
-    public function fieldToDb(CsvField $csvField)
+    public static function fieldToDb(CsvField $csvField)
     {
         $dbFields = parent::fieldToDb($csvField);
 

--- a/src/FieldHandlers/FieldHandlerInterface.php
+++ b/src/FieldHandlers/FieldHandlerInterface.php
@@ -90,5 +90,5 @@ interface FieldHandlerInterface
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
      * @return array                                           DbField instances
      */
-    public function fieldToDb(CsvField $csvField);
+    public static function fieldToDb(CsvField $csvField);
 }

--- a/src/FieldHandlers/MetricFieldHandler.php
+++ b/src/FieldHandlers/MetricFieldHandler.php
@@ -6,19 +6,16 @@ use CsvMigrations\FieldHandlers\BaseCombinedFieldHandler;
 class MetricFieldHandler extends BaseCombinedFieldHandler
 {
     /**
-     * Set combined fields
+     * Combined fields
      *
-     * @return void
+     * @var array
      */
-    protected function _setCombinedFields()
-    {
-        $this->_fields = [
-            'amount' => [
-                'handler' => __NAMESPACE__ . '\\DecimalFieldHandler'
-            ],
-            'unit' => [
-                'handler' => __NAMESPACE__ . '\\ListFieldHandler'
-            ]
-        ];
-    }
+    protected static $_fields = [
+        'amount' => [
+            'handler' => __NAMESPACE__ . '\\DecimalFieldHandler'
+        ],
+        'unit' => [
+            'handler' => __NAMESPACE__ . '\\ListFieldHandler'
+        ]
+    ];
 }

--- a/src/FieldHandlers/MoneyFieldHandler.php
+++ b/src/FieldHandlers/MoneyFieldHandler.php
@@ -6,19 +6,16 @@ use CsvMigrations\FieldHandlers\BaseCombinedFieldHandler;
 class MoneyFieldHandler extends BaseCombinedFieldHandler
 {
     /**
-     * Set combined fields
+     * Combined fields
      *
-     * @return void
+     * @var array
      */
-    protected function _setCombinedFields()
-    {
-        $this->_fields = [
-            'amount' => [
-                'handler' => __NAMESPACE__ . '\\DecimalFieldHandler'
-            ],
-            'currency' => [
-                'handler' => __NAMESPACE__ . '\\ListFieldHandler'
-            ]
-        ];
-    }
+    protected static $_fields = [
+        'amount' => [
+            'handler' => __NAMESPACE__ . '\\DecimalFieldHandler'
+        ],
+        'currency' => [
+            'handler' => __NAMESPACE__ . '\\ListFieldHandler'
+        ]
+    ];
 }

--- a/src/FieldHandlers/TextFieldHandler.php
+++ b/src/FieldHandlers/TextFieldHandler.php
@@ -26,7 +26,7 @@ class TextFieldHandler extends BaseStringFieldHandler
      * @param  \CsvMigrations\FieldHandlers\CsvField $csvField CsvField instance
      * @return array                                           DbField instances
      */
-    public function fieldToDb(CsvField $csvField)
+    public static function fieldToDb(CsvField $csvField)
     {
         $csvField->setType(self::DB_FIELD_TYPE);
         // Set the limit to Phinx\Db\Adapter\MysqlAdapter::TEXT_LONG
@@ -34,7 +34,7 @@ class TextFieldHandler extends BaseStringFieldHandler
 
         $dbField = DbField::fromCsvField($csvField);
         $result = [
-            $this->field => $dbField,
+            $csvField->getName() => $dbField,
         ];
 
         return $result;

--- a/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
@@ -26,7 +26,8 @@ class BlobFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
@@ -26,7 +26,7 @@ class BlobFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/BooleanFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/BooleanFieldHandlerTest.php
@@ -26,7 +26,7 @@ class BooleanFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/BooleanFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/BooleanFieldHandlerTest.php
@@ -26,7 +26,8 @@ class BooleanFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/DateFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DateFieldHandlerTest.php
@@ -27,7 +27,8 @@ class DateFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/DateFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DateFieldHandlerTest.php
@@ -27,7 +27,7 @@ class DateFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/DatetimeFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DatetimeFieldHandlerTest.php
@@ -27,7 +27,8 @@ class DatetimeFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/DatetimeFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DatetimeFieldHandlerTest.php
@@ -27,7 +27,7 @@ class DatetimeFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/DblistFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DblistFieldHandlerTest.php
@@ -26,7 +26,7 @@ class DblistFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/DblistFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DblistFieldHandlerTest.php
@@ -26,7 +26,8 @@ class DblistFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/DecimalFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DecimalFieldHandlerTest.php
@@ -26,7 +26,8 @@ class DecimalFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/DecimalFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DecimalFieldHandlerTest.php
@@ -26,7 +26,7 @@ class DecimalFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/EmailFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/EmailFieldHandlerTest.php
@@ -26,7 +26,7 @@ class EmailFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/EmailFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/EmailFieldHandlerTest.php
@@ -26,7 +26,8 @@ class EmailFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/FilesFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/FilesFieldHandlerTest.php
@@ -26,7 +26,7 @@ class FilesFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/FilesFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/FilesFieldHandlerTest.php
@@ -26,7 +26,8 @@ class FilesFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/HasManyFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/HasManyFieldHandlerTest.php
@@ -26,7 +26,7 @@ class HasManyFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/HasManyFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/HasManyFieldHandlerTest.php
@@ -26,7 +26,8 @@ class HasManyFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/ImagesFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/ImagesFieldHandlerTest.php
@@ -26,7 +26,7 @@ class ImagesFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/ImagesFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/ImagesFieldHandlerTest.php
@@ -26,7 +26,8 @@ class ImagesFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/IntegerFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/IntegerFieldHandlerTest.php
@@ -50,7 +50,8 @@ class IntegerFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/IntegerFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/IntegerFieldHandlerTest.php
@@ -50,7 +50,7 @@ class IntegerFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/ListFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/ListFieldHandlerTest.php
@@ -26,7 +26,7 @@ class ListFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/ListFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/ListFieldHandlerTest.php
@@ -26,7 +26,8 @@ class ListFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/MetricFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/MetricFieldHandlerTest.php
@@ -28,7 +28,8 @@ class MetricFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/MetricFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/MetricFieldHandlerTest.php
@@ -28,7 +28,7 @@ class MetricFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/MoneyFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/MoneyFieldHandlerTest.php
@@ -28,7 +28,8 @@ class MoneyFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/MoneyFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/MoneyFieldHandlerTest.php
@@ -28,7 +28,7 @@ class MoneyFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/PhoneFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/PhoneFieldHandlerTest.php
@@ -26,7 +26,8 @@ class PhoneFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/PhoneFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/PhoneFieldHandlerTest.php
@@ -26,7 +26,7 @@ class PhoneFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
@@ -26,7 +26,7 @@ class RelatedFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
@@ -26,7 +26,8 @@ class RelatedFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/ReminderFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/ReminderFieldHandlerTest.php
@@ -27,7 +27,8 @@ class ReminderFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/ReminderFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/ReminderFieldHandlerTest.php
@@ -27,7 +27,7 @@ class ReminderFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/StringFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/StringFieldHandlerTest.php
@@ -26,7 +26,7 @@ class StringFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/StringFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/StringFieldHandlerTest.php
@@ -26,7 +26,8 @@ class StringFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/SublistFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/SublistFieldHandlerTest.php
@@ -26,7 +26,8 @@ class SublistFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/SublistFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/SublistFieldHandlerTest.php
@@ -26,7 +26,7 @@ class SublistFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/TextFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/TextFieldHandlerTest.php
@@ -26,7 +26,8 @@ class TextFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/TextFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/TextFieldHandlerTest.php
@@ -26,7 +26,7 @@ class TextFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
@@ -27,7 +27,8 @@ class TimeFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
@@ -27,7 +27,7 @@ class TimeFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/UrlFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/UrlFieldHandlerTest.php
@@ -26,7 +26,7 @@ class UrlFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/UrlFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/UrlFieldHandlerTest.php
@@ -26,7 +26,8 @@ class UrlFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/UuidFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/UuidFieldHandlerTest.php
@@ -26,7 +26,8 @@ class UuidFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh::fieldToDb($csvField);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");

--- a/tests/TestCase/FieldHandlers/UuidFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/UuidFieldHandlerTest.php
@@ -26,7 +26,7 @@ class UuidFieldHandlerTest extends PHPUnit_Framework_TestCase
     public function testFieldToDb()
     {
         $csvField = new CsvField(['name' => $this->field, 'type' => 'text']);
-        $result = $this->fh->fieldToDb($csvField);
+        $result = $this->fh::fieldToDb($csvField);
 
         $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
         $this->assertFalse(empty($result), "fieldToDb() returned an empty array");


### PR DESCRIPTION
`fieldToDb()` method is used in several different scenarios.  In
some, it's similar to other field handler methods, where we know
the table, field, options, etc.

But in some others (for example, during the migrations run), we
might not know or even have a table.  Since the method itself does
not rely on any runtime functionality, it can be made static and
used for the migration or testing purposes without the full blown
field handler intance.