### PR TITLE
Dynamic panels bugfix (task #3336)

### DIFF
--- a/webroot/js/panels.js
+++ b/webroot/js/panels.js
@@ -64,8 +64,9 @@
     };
 
     Panel.prototype.resetPanels = function () {
-        $('[data-provide="dynamic-panel"].hidden').find(':input').attr('disabled', false);
-        $('[data-provide="dynamic-panel"]').removeClass('hidden');
+        var $form = this.form;
+        $form.find('[data-provide="dynamic-panel"].hidden').find(':input').attr('disabled', false);
+        $form.find('[data-provide="dynamic-panel"]').removeClass('hidden');
     };
 
     Panel.prototype.observe = function () {


### PR DESCRIPTION
When `resetPanels` logic kicks in, it should target only the current form's panels, not all DOM panels.