### PR TITLE
allowing to output raw content to TabContent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "license": "GPL-2.0",
     "require": {
-        "cakephp/cakephp": ">3.0.0 <4.0",
+        "cakephp/cakephp": "~3.3.0",
         "cakephp/migrations": "~1.0",
         "league/csv": "^8.1",
         "piwik/ini": "^1.0",

--- a/src/Template/Element/View/view.ctp
+++ b/src/Template/Element/View/view.ctp
@@ -271,7 +271,7 @@ echo $this->element('CsvMigrations.common_js_libs');
                         $this->eventManager()->dispatch($tabContentEvent);
                         $content = $tabContentEvent->result;
 
-                        if (!empty($content)) {
+                        if (!empty($content) && !isset($content['rawOutput'])) {
                             echo $this->cell('CsvMigrations.TabContent', [
                             [
                                 'request' => $this->request,
@@ -281,7 +281,13 @@ echo $this->element('CsvMigrations.common_js_libs');
                                 'entity' => $options['entity'],
                             ]
                             ]);
+                        }
 
+                        if (!empty($content['rawOutput'])) {
+                            echo $content['rawOutput'];
+                        }
+
+                        if (!empty($content)) {
                             echo $this->Html->scriptBlock(
                                 '$(".' . $tab['containerId'] . '").DataTable({
                                         "paging": true,


### PR DESCRIPTION
Most of the rendering logic of Tabs goes through the cells, that sets certain restrictions on the data format. 
It makes passing custom content in the TabContent event difficult, so we set an option of `rawOutput` array to pass data in the view element.