### PR TITLE
Predefined select options

### DIFF
--- a/src/FieldHandlers/ListFieldHandler.php
+++ b/src/FieldHandlers/ListFieldHandler.php
@@ -26,11 +26,16 @@ class ListFieldHandler extends BaseCsvListFieldHandler
     {
         $options = array_merge($this->defaultOptions, $this->fixOptions($options));
         $data = $this->_getFieldValueFromData($data);
+        $selectOptions = ['' => static::EMPTY_OPTION_LABEL];
 
         $fieldName = $this->table->aliasField($this->field);
 
-        $selectOptions = ['' => static::EMPTY_OPTION_LABEL];
-        $selectOptions += $this->_getSelectOptions($options['fieldDefinitions']->getLimit());
+        // if select options are not pre-defined
+        if (empty($options['selectOptions'])) {
+            $selectOptions += $this->_getSelectOptions($options['fieldDefinitions']->getLimit());
+        } else {
+            $selectOptions += $options['selectOptions'];
+        }
 
         $params = [
             'field' => $this->field,


### PR DESCRIPTION
Current ListFieldHandler only relies on CSV options and DbList functionality.

This patch, allows to bypass this and allow users to pass select options on its own.