### PR TITLE
Search options (task #3290)

### DIFF
--- a/src/FieldHandlers/BaseRelatedFieldHandler.php
+++ b/src/FieldHandlers/BaseRelatedFieldHandler.php
@@ -201,6 +201,7 @@ abstract class BaseRelatedFieldHandler extends BaseFieldHandler
             ])
         );
 
+        $result[$this->field]['source'] = $options['fieldDefinitions']->getLimit();
         $result[$this->field]['input'] = [
             'content' => $content,
             'post' => [

--- a/webroot/js/select2.init.js
+++ b/webroot/js/select2.init.js
@@ -139,6 +139,7 @@ var csv_migrations_select2 = csv_migrations_select2 || {};
         $.ajax({
             url: url,
             type: 'get',
+            data: { format: 'pretty' },
             dataType: 'json',
             contentType: 'application/json',
             headers: {

--- a/webroot/js/select2.init.js
+++ b/webroot/js/select2.init.js
@@ -68,6 +68,9 @@ var csv_migrations_select2 = csv_migrations_select2 || {};
             width: '100%',
             placeholder: placeholder,
             minimumInputLength: that.min_length,
+            escapeMarkup: function (text) {
+                return text;
+            },
             ajax: {
                 url: $(input).data('url'),
                 dataType: 'json',


### PR DESCRIPTION
- Add `source` to search options, used to specify related Module or list name.
- Properly display special characters on select2 options label.
- Fixed issue when fetching select2 label from a property where its `display field` is a `related field`. Currently the select2 label will hold the `uuid` value of the entity's associated record, instead of the `display field` of the entity's associated record.