### PR TITLE
Let native Cake models be used in index.ctp

### DIFF
--- a/src/Events/IndexViewListener.php
+++ b/src/Events/IndexViewListener.php
@@ -179,9 +179,11 @@ class IndexViewListener extends BaseViewListener
 
         $sortCols = $fields[$sortCol];
         // handle virtual field
-        $virtualFields = $table->getVirtualFields();
-        if (!empty($virtualFields) && isset($virtualFields[$sortCols])) {
-            $sortCols = $virtualFields[$sortCols];
+        if (method_exists($table, 'getVirtualFields') && is_callable([$table, 'getVirtualFields'])) {
+            $virtualFields = $table->getVirtualFields();
+            if (!empty($virtualFields) && isset($virtualFields[$sortCols])) {
+                $sortCols = $virtualFields[$sortCols];
+            }
         }
         $sortCols = (array)$sortCols;
 


### PR DESCRIPTION
In order to use CSV Module for native Cake models we make sure that getVirtualFields method exist in it. Otherwise, we fall back to native sorting without any virtual fields.