### PR TITLE
Embedded cancel button (task #3472)

### DIFF
--- a/src/Template/Element/View/add.ctp
+++ b/src/Template/Element/View/add.ctp
@@ -159,8 +159,22 @@ if (!empty($this->request->query['embedded'])) {
     if (!$this->request->param('pass.conversion')) {
         echo $this->Form->button(__('Submit'), ['name' => 'btn_operation', 'value' => 'submit', 'class' => 'btn btn-primary']);
         echo "&nbsp;";
-        echo $this->Form->button(__('Cancel'), ['name' => 'btn_operation', 'value' => 'cancel', 'class' => 'btn']);
 
+        $cancelBtnOptions = [
+            'name' => 'btn_operation',
+            'value' => 'cancel',
+            'class' => 'btn',
+        ];
+
+        if ($this->request->query('embedded')) {
+            $cancelBtnOptions = array_merge($cancelBtnOptions, [
+                'type' => 'button',
+                'aria-label' => 'Close',
+                'data-dismiss' => 'modal',
+            ]);
+        }
+
+        echo $this->Form->button(__('Cancel'), $cancelBtnOptions);
         echo $this->Form->end();
     }
     ?>

--- a/src/Template/Element/View/edit.ctp
+++ b/src/Template/Element/View/edit.ctp
@@ -149,8 +149,21 @@ if (!empty($this->request->query['embedded'])) {
     if (!$this->request->param('pass.conversion')) {
         echo $this->Form->button(__('Submit'), ['name' => 'btn_operation', 'value' => 'submit', 'class' => 'btn btn-primary']);
         echo "&nbsp;";
-        echo $this->Form->button(__('Cancel'), ['name' => 'btn_operation', 'value' => 'cancel', 'class' => 'btn']);
+        $cancelBtnOptions = [
+            'name' => 'btn_operation',
+            'value' => 'cancel',
+            'class' => 'btn'
+        ];
 
+        if ($this->request->query('embedded')) {
+            $cancelBtnOptions = array_merge($cancelBtnOptions, [
+                'type' => 'button',
+                'aria-label' => 'Close',
+                'data-dismiss' => 'modal',
+            ]);
+        }
+
+        echo $this->Form->button(__('Cancel'), $cancelBtnOptions);
         echo $this->Form->end();
     }
     ?>


### PR DESCRIPTION
Once using embedded forms with modals, "cancel" button shouldn't be submitting the form.
It's adjusted as per Bootstrap modal example, with dismissing the modal rather then sending POST request.