### PR TITLE
fields.ini format parameter (task #2970)

### DIFF
--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -13,7 +13,7 @@ use CsvMigrations\View\AppView;
 use Exception;
 use InvalidArgumentException;
 use Qobo\Utils\Parser\Ini\Parser as IniParser;
-use Qobo\Utils\PathFinder\ConfigPathFinder;
+use Qobo\Utils\PathFinder\FieldsIniPathFinder;
 use RuntimeException;
 
 /**
@@ -29,11 +29,6 @@ use RuntimeException;
  */
 abstract class BaseFieldHandler implements FieldHandlerInterface
 {
-    /**
-     * Fields ini filename
-     */
-    const FIELDS_INI_FILENAME = 'fields.ini';
-
     /**
      * Default database field type
      */
@@ -551,8 +546,8 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
     {
         $result = '';
         try {
-            $pathFinder = new ConfigPathFinder;
-            $result = $pathFinder->find(Inflector::camelize($this->table->table()), static::FIELDS_INI_FILENAME);
+            $pathFinder = new FieldsIniPathFinder;
+            $result = $pathFinder->find(Inflector::camelize($this->table->table()));
         } catch (Exception $e) {
             //
         }

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -13,7 +13,7 @@ use CsvMigrations\View\AppView;
 use Exception;
 use InvalidArgumentException;
 use Qobo\Utils\Parser\Ini\Parser as IniParser;
-use Qobo\Utils\PathFinder\FieldsIniPathFinder;
+use Qobo\Utils\PathFinder\FieldsPathFinder;
 use RuntimeException;
 
 /**
@@ -387,7 +387,7 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
 
         $path = '';
         try {
-            $pathFinder = new FieldsIniPathFinder;
+            $pathFinder = new FieldsPathFinder;
             $path = $pathFinder->find(Inflector::camelize($this->table->table()));
         } catch (Exception $e) {
             //
@@ -533,7 +533,7 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
         if (!$result) {
             $path = '';
             try {
-                $pathFinder = new FieldsIniPathFinder;
+                $pathFinder = new FieldsPathFinder;
                 $path = $pathFinder->find(Inflector::camelize($this->table->table()));
             } catch (Exception $e) {
                 //

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -385,7 +385,13 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
     {
         $text = $this->field;
 
-        $path = $this->_getFieldsIniPath();
+        $path = '';
+        try {
+            $pathFinder = new FieldsIniPathFinder;
+            $path = $pathFinder->find(Inflector::camelize($this->table->table()));
+        } catch (Exception $e) {
+            //
+        }
         $parser = new IniParser;
         $label = $parser->getFieldsIniParams($path, $text, 'label');
         if ($label) {
@@ -525,31 +531,19 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
         }
 
         if (!$result) {
-            $path = $this->_getFieldsIniPath();
+            $path = '';
+            try {
+                $pathFinder = new FieldsIniPathFinder;
+                $path = $pathFinder->find(Inflector::camelize($this->table->table()));
+            } catch (Exception $e) {
+                //
+            }
             $parser = new IniParser;
             $default = $parser->getFieldsIniParams($path, $field, 'default');
             if (empty($default)) {
                 return $result;
             }
             $result = $default;
-        }
-
-        return $result;
-    }
-
-    /**
-     * Gets fields ini configuration file path.
-     *
-     * @return string
-     */
-    protected function _getFieldsIniPath()
-    {
-        $result = '';
-        try {
-            $pathFinder = new FieldsIniPathFinder;
-            $result = $pathFinder->find(Inflector::camelize($this->table->table()));
-        } catch (Exception $e) {
-            //
         }
 
         return $result;

--- a/src/FieldHandlers/BaseNumberFieldHandler.php
+++ b/src/FieldHandlers/BaseNumberFieldHandler.php
@@ -5,7 +5,7 @@ use Cake\Utility\Inflector;
 use CsvMigrations\FieldHandlers\BaseSimpleFieldHandler;
 use Exception;
 use Qobo\Utils\Parser\Ini\Parser;
-use Qobo\Utils\PathFinder\FieldsIniPathFinder;
+use Qobo\Utils\PathFinder\FieldsPathFinder;
 
 abstract class BaseNumberFieldHandler extends BaseSimpleFieldHandler
 {
@@ -83,7 +83,7 @@ abstract class BaseNumberFieldHandler extends BaseSimpleFieldHandler
 
         $path = '';
         try {
-            $pathFinder = new FieldsIniPathFinder;
+            $pathFinder = new FieldsPathFinder;
             $path = $pathFinder->find(Inflector::camelize($this->table->table()));
         } catch (Exception $e) {
             //

--- a/src/FieldHandlers/BaseNumberFieldHandler.php
+++ b/src/FieldHandlers/BaseNumberFieldHandler.php
@@ -2,6 +2,7 @@
 namespace CsvMigrations\FieldHandlers;
 
 use CsvMigrations\FieldHandlers\BaseSimpleFieldHandler;
+use Qobo\Utils\Parser\Ini\Parser;
 
 abstract class BaseNumberFieldHandler extends BaseSimpleFieldHandler
 {
@@ -76,6 +77,13 @@ abstract class BaseNumberFieldHandler extends BaseSimpleFieldHandler
     protected function formatValue($data, array $options = [])
     {
         $result = (float)$data;
+
+        $path = $this->_getFieldsIniPath();
+        $parser = new Parser;
+        $format = $parser->getFieldsIniParams($path, $this->field, 'format');
+        if ('raw' === $format) {
+            return $result;
+        }
 
         if (!empty($result) && is_numeric($result)) {
             $result = number_format($result, static::PRECISION);

--- a/src/FieldHandlers/BaseNumberFieldHandler.php
+++ b/src/FieldHandlers/BaseNumberFieldHandler.php
@@ -1,8 +1,11 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
+use Cake\Utility\Inflector;
 use CsvMigrations\FieldHandlers\BaseSimpleFieldHandler;
+use Exception;
 use Qobo\Utils\Parser\Ini\Parser;
+use Qobo\Utils\PathFinder\FieldsIniPathFinder;
 
 abstract class BaseNumberFieldHandler extends BaseSimpleFieldHandler
 {
@@ -78,7 +81,14 @@ abstract class BaseNumberFieldHandler extends BaseSimpleFieldHandler
     {
         $result = (float)$data;
 
-        $path = $this->_getFieldsIniPath();
+        $path = '';
+        try {
+            $pathFinder = new FieldsIniPathFinder;
+            $path = $pathFinder->find(Inflector::camelize($this->table->table()));
+        } catch (Exception $e) {
+            //
+        }
+
         $parser = new Parser;
         $format = $parser->getFieldsIniParams($path, $this->field, 'format');
         if ('raw' === $format) {


### PR DESCRIPTION
Add check for `format` parameter in `fields.ini` configuration. If the parameter value is `raw`, then we skip formatting the number values.