### PR TITLE
Fields ini renderAs (task 2970)

### DIFF
--- a/src/FieldHandlers/BaseCsvListFieldHandler.php
+++ b/src/FieldHandlers/BaseCsvListFieldHandler.php
@@ -22,21 +22,22 @@ abstract class BaseCsvListFieldHandler extends BaseListFieldHandler
     const VALUE_NOT_FOUND_HTML = '%s <span class="text-danger glyphicon glyphicon-exclamation-sign" title="Invalid list item" aria-hidden="true"></span>';
 
     /**
-     * Render field value
+     * Format field value
      *
-     * This method prepares the output of the value for the given
-     * field.  The result can be controlled via the variety of
-     * options.
+     * This method provides a customization point for formatting
+     * of the field value before rendering.
      *
-     * @param  string $data    Field data
-     * @param  array  $options Field options
-     * @return string          Field value
+     * NOTE: The value WILL NOT be sanitized during the formatting.
+     *       It is assumed that sanitization happens either before
+     *       or after this method is called.
+     *
+     * @param mixed $data    Field value data
+     * @param array $options Field formatting options
+     * @return string
      */
-    public function renderValue($data, array $options = [])
+    protected function formatValue($data, array $options = [])
     {
         $result = '';
-        $options = array_merge($this->defaultOptions, $this->fixOptions($options));
-        $data = $this->_getFieldValueFromData($data);
 
         if (empty($data)) {
             return $result;
@@ -63,7 +64,6 @@ abstract class BaseCsvListFieldHandler extends BaseListFieldHandler
                 $result = sprintf(static::VALUE_NOT_FOUND_HTML, $data);
             }
         }
-        $result = $this->sanitizeValue($result, $options);
 
         return $result;
     }

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -445,7 +445,32 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
         $result = (string)$this->_getFieldValueFromData($data);
         $result = $this->sanitizeValue($result, $options);
 
+        if (!empty($options['renderAs']) && static::RENDER_PLAIN_VALUE === $options['renderAs']) {
+            return $result;
+        }
+
+        $result = $this->formatValue($result, $options);
+
         return $result;
+    }
+
+    /**
+     * Format field value
+     *
+     * This method provides a customization point for formatting
+     * of the field value before rendering.
+     *
+     * NOTE: The value WILL NOT be sanitized during the formatting.
+     *       It is assumed that sanitization happens either before
+     *       or after this method is called.
+     *
+     * @param mixed $data    Field value data
+     * @param array $options Field formatting options
+     * @return string
+     */
+    protected function formatValue($data, array $options = [])
+    {
+        return (string)$data;
     }
 
     /**

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -202,6 +202,20 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
 
         // set $options['label']
         $this->defaultOptions['label'] = $this->renderName();
+
+        $path = '';
+        try {
+            $pathFinder = new FieldsPathFinder;
+            $path = $pathFinder->find(Inflector::camelize($this->table->table()));
+        } catch (Exception $e) {
+            //
+        }
+        $parser = new IniParser;
+        $renderAs = $parser->getFieldsIniParams($path, $this->field, 'renderAs');
+
+        if (!empty($renderAs)) {
+            $this->defaultOptions['renderAs'] = $renderAs;
+        }
     }
 
     /**

--- a/src/FieldHandlers/BaseListFieldHandler.php
+++ b/src/FieldHandlers/BaseListFieldHandler.php
@@ -33,31 +33,6 @@ abstract class BaseListFieldHandler extends BaseFieldHandler
     ];
 
     /**
-     * Render field value
-     *
-     * This method prepares the output of the value for the given
-     * field.  The result can be controlled via the variety of
-     * options.
-     *
-     * @param  string $data    Field data
-     * @param  array  $options Field options
-     * @return string          Field value
-     */
-    public function renderValue($data, array $options = [])
-    {
-        $options = array_merge($this->defaultOptions, $this->fixOptions($options));
-        $result = parent::renderValue($data, $options);
-
-        if (!empty($options['renderAs']) && static::RENDER_PLAIN_VALUE === $options['renderAs']) {
-            return $result;
-        }
-
-        $result = $this->formatValue($result, $options);
-
-        return $result;
-    }
-
-    /**
      * Convert CsvField to one or more DbField instances
      *
      * Simple fields from migrations CSV map one-to-one to

--- a/src/FieldHandlers/BaseListFieldHandler.php
+++ b/src/FieldHandlers/BaseListFieldHandler.php
@@ -33,6 +33,31 @@ abstract class BaseListFieldHandler extends BaseFieldHandler
     ];
 
     /**
+     * Render field value
+     *
+     * This method prepares the output of the value for the given
+     * field.  The result can be controlled via the variety of
+     * options.
+     *
+     * @param  string $data    Field data
+     * @param  array  $options Field options
+     * @return string          Field value
+     */
+    public function renderValue($data, array $options = [])
+    {
+        $options = array_merge($this->defaultOptions, $this->fixOptions($options));
+        $result = parent::renderValue($data, $options);
+
+        if (!empty($options['renderAs']) && static::RENDER_PLAIN_VALUE === $options['renderAs']) {
+            return $result;
+        }
+
+        $result = $this->formatValue($result, $options);
+
+        return $result;
+    }
+
+    /**
      * Convert CsvField to one or more DbField instances
      *
      * Simple fields from migrations CSV map one-to-one to

--- a/src/FieldHandlers/BaseSimpleFieldHandler.php
+++ b/src/FieldHandlers/BaseSimpleFieldHandler.php
@@ -9,47 +9,4 @@ namespace CsvMigrations\FieldHandlers;
  */
 abstract class BaseSimpleFieldHandler extends BaseFieldHandler
 {
-    /**
-     * Format field value
-     *
-     * This method provides a customization point for formatting
-     * of the field value before rendering.
-     *
-     * NOTE: The value WILL NOT be sanitized during the formatting.
-     *       It is assumed that sanitization happens either before
-     *       or after this method is called.
-     *
-     * @param mixed $data    Field value data
-     * @param array $options Field formatting options
-     * @return string
-     */
-    protected function formatValue($data, array $options = [])
-    {
-        return (string)$data;
-    }
-
-    /**
-     * Render field value
-     *
-     * This method prepares the output of the value for the given
-     * field.  The result can be controlled via the variety of
-     * options.
-     *
-     * @param  string $data    Field data
-     * @param  array  $options Field options
-     * @return string          Field value
-     */
-    public function renderValue($data, array $options = [])
-    {
-        $options = array_merge($this->defaultOptions, $this->fixOptions($options));
-        $result = parent::renderValue($data, $options);
-
-        if (!empty($options['renderAs']) && static::RENDER_PLAIN_VALUE === $options['renderAs']) {
-            return $result;
-        }
-
-        $result = $this->formatValue($result, $options);
-
-        return $result;
-    }
 }

--- a/src/FieldHandlers/BaseSimpleFieldHandler.php
+++ b/src/FieldHandlers/BaseSimpleFieldHandler.php
@@ -1,8 +1,6 @@
 <?php
 namespace CsvMigrations\FieldHandlers;
 
-use CsvMigrations\FieldHandlers\BaseFieldHandler;
-
 /**
  * BaseSimpleFieldHandler
  *
@@ -45,6 +43,11 @@ abstract class BaseSimpleFieldHandler extends BaseFieldHandler
     {
         $options = array_merge($this->defaultOptions, $this->fixOptions($options));
         $result = parent::renderValue($data, $options);
+
+        if (!empty($options['renderAs']) && static::RENDER_PLAIN_VALUE === $options['renderAs']) {
+            return $result;
+        }
+
         $result = $this->formatValue($result, $options);
 
         return $result;

--- a/src/FieldHandlers/DblistFieldHandler.php
+++ b/src/FieldHandlers/DblistFieldHandler.php
@@ -51,31 +51,30 @@ class DblistFieldHandler extends BaseListFieldHandler
     }
 
     /**
-     * Render field value
+     * Format field value
      *
-     * This method prepares the output of the value for the given
-     * field.  The result can be controlled via the variety of
-     * options.
+     * This method provides a customization point for formatting
+     * of the field value before rendering.
      *
-     * @param  string $data    Field data
-     * @param  array  $options Field options
-     * @return string          Field value
+     * NOTE: The value WILL NOT be sanitized during the formatting.
+     *       It is assumed that sanitization happens either before
+     *       or after this method is called.
+     *
+     * @param mixed $data    Field value data
+     * @param array $options Field formatting options
+     * @return string
      */
-    public function renderValue($data, array $options = [])
+    public function formatValue($data, array $options = [])
     {
-        $result = '';
-        $options = array_merge($this->defaultOptions, $this->fixOptions($options));
-        $data = $this->_getFieldValueFromData($data);
-
         //CsvField object is mandatory
         if (!isset($options['fieldDefinitions']) ||
             !($options['fieldDefinitions'] instanceof CsvField)) {
-            return $result;
+            return $data;
         }
-        $csvObj = $options['fieldDefinitions'];
-        $list = $csvObj->getListName();
 
-        return $this->cakeView->cell('CsvMigrations.Dblist::' . __FUNCTION__, [$data, $list])->render(__FUNCTION__);
+        $list = $options['fieldDefinitions']->getListName();
+
+        return $this->cakeView->cell('CsvMigrations.Dblist::renderValue', [$data, $list])->render('renderValue');
     }
 
     /**


### PR DESCRIPTION
Changed format logic to use options `renderAs` parameter. If the parameter value is set to `plain` then we skip calling the `formatValue()` method and we return the value as is.