### PR TITLE
Auto increment Event listener (task #3481)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -9,6 +9,7 @@ use CsvMigrations\Events\IndexViewListener;
 use CsvMigrations\Events\LayoutListener;
 use CsvMigrations\Events\LookupListener;
 use CsvMigrations\Events\ModelAfterSaveListener;
+use CsvMigrations\Events\Model\AutoIncrementEventListener;
 use CsvMigrations\Events\ReportListener;
 use CsvMigrations\Events\ViewViewListener;
 use CsvMigrations\Events\ViewViewTabsListener;
@@ -29,6 +30,7 @@ Configure::write('CsvMigrations', array_replace_recursive(
     $config
 ));
 
+EventManager::instance()->on(new AutoIncrementEventListener());
 EventManager::instance()->on(new AddViewListener());
 EventManager::instance()->on(new EditViewListener());
 EventManager::instance()->on(new IndexViewListener());

--- a/src/Events/Model/AutoIncrementEventListener.php
+++ b/src/Events/Model/AutoIncrementEventListener.php
@@ -63,12 +63,13 @@ class AutoIncrementEventListener implements EventListenerInterface
             $query = $event->subject()->find('withTrashed');
             $query->select([$field => $query->func()->max($field)]);
             $max = $query->first()->toArray();
+            $max = (float)$max[$field];
 
             if (empty($options['min'])) {
-                $entity->{$field} = $max[$field] + 1;
+                $entity->{$field} = $max + 1;
             } else {
                 // if value is less than the allowed minimum, then set it to the minimum.
-                $entity->{$field} = $max[$field] < $options['min'] ? $options['min'] : $max[$field] + 1;
+                $entity->{$field} = $max < $options['min'] ? $options['min'] : $max + 1;
             }
         }
     }

--- a/src/Events/Model/AutoIncrementEventListener.php
+++ b/src/Events/Model/AutoIncrementEventListener.php
@@ -1,0 +1,121 @@
+<?php
+namespace CsvMigrations\Events\Model;
+
+use ArrayObject;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\Utility\Inflector;
+use CsvMigrations\Table;
+use Exception;
+use Qobo\Utils\Parser\Ini\Parser;
+use Qobo\Utils\PathFinder\FieldsPathFinder;
+use Qobo\Utils\PathFinder\MigrationPathFinder;
+
+class AutoIncrementEventListener implements EventListenerInterface
+{
+    /**
+     * Implemented Events
+     *
+     * @return array
+     */
+    public function implementedEvents()
+    {
+        return [
+            'Model.beforeSave' => 'autoIncrementFieldValue',
+        ];
+    }
+
+    /**
+     * Auto-increment reference number.
+     *
+     * @param  Cake\Event\Event $event Event object
+     * @param  Cake\Datasource\EntityInterface $entity Translation entity
+     * @param  ArrayObject $options entity options
+     * @return void
+     */
+    public function autoIncrementFieldValue(Event $event, EntityInterface $entity, ArrayObject $options)
+    {
+        $table = $event->subject();
+
+        if (!$table instanceof Table) {
+            return;
+        }
+
+        $autoIncrementFields = $this->_getAutoIncrementFields($table);
+
+        // skip if no auto-increment fields are defined
+        if (empty($autoIncrementFields)) {
+            return;
+        }
+
+        // skip modifying auto-increment field(s) on existing records.
+        if (!$entity->isNew()) {
+            foreach (array_keys($autoIncrementFields) as $field) {
+                $entity->unsetProperty($field);
+            }
+
+            return;
+        }
+
+        foreach ($autoIncrementFields as $field => $options) {
+            // get max value
+            $query = $event->subject()->find('withTrashed');
+            $query->select([$field => $query->func()->max($field)]);
+            $max = $query->first()->toArray();
+
+            if (empty($options['min'])) {
+                $entity->{$field} = $max[$field] + 1;
+            } else {
+                // if value is less than the allowed minimum, then set it to the minimum.
+                $entity->{$field} = $max[$field] < $options['min'] ? $options['min'] : $max[$field] + 1;
+            }
+        }
+    }
+
+    /**
+     * Retrieves auto-increment fields for specified Module.
+     *
+     * Retrieves and returns auto-increment fields along with their
+     * related properties (such as 'min' value).
+     *
+     * @param \CsvMigrations\Table $table Table instance
+     * @return array
+     */
+    protected function _getAutoIncrementFields(table $table)
+    {
+        $result = [];
+
+        $moduleName = Inflector::camelize($table->table());
+        $path = '';
+        try {
+            $pathFinder = new FieldsPathFinder;
+            $path = $pathFinder->find($moduleName);
+        } catch (Exception $e) {
+            // do nothing
+        }
+
+        if (!empty($path)) {
+            $parser = new Parser;
+            $moduleFields = $table->getFieldsDefinitions();
+            foreach (array_keys($moduleFields) as $field) {
+                $autoIncrement = (bool)$parser->getFieldsIniParams($path, $field, 'auto-increment');
+                if (!$autoIncrement) {
+                    continue;
+                }
+                $result[$field] = [];
+
+                $min = $parser->getFieldsIniParams($path, $field, 'min');
+                if (!is_int($min) && !is_float($min)) {
+                    continue;
+                }
+
+                $result[$field] = [
+                    'min' => $min
+                ];
+            }
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
Added event listener for handling fields defined as auto-incremental using `fields.ini` configuration. Currently, supported paramaters are `auto-increment` and `min`. Currently stepping is always one,
so an integer starting from 0 will increment like 1, 2, 3 etc and a decimal starting from 0.5 will increment like 1.5, 2.5, 3.5 etc.

To define a field as auto-incremental you just add the following lines to `fields.ini` configuration file:

```ini
[field_name_goes_here]
auto-increment = true
```

You can optionally set the `min` parameter to specify the starting point of the auto-increment functionality. See example below:

```ini
[field_name_goes_here]
auto-increment = true
min = 100
```

So the first record created, with the above configuration in place, will have the field value set to 100. The next one will be set to 101 etc.