### PR TITLE
Allow trashed field to be null

### DIFF
--- a/src/CsvMigration.php
+++ b/src/CsvMigration.php
@@ -68,7 +68,7 @@ class CsvMigration extends AbstractMigration
         'trashed' => [
             'name' => 'trashed',
             'type' => 'datetime',
-            'required' => true,
+            'required' => false,
             'non-searchable' => true,
             'unique' => false
         ]


### PR DESCRIPTION
CakePHP handles the values correctly, so we don't need to be too
strict.  Null vs. '0000-00-00 00:00:00' causes some issues in left
joins though.