### PR TITLE
Replaced Parsers and PathFinders with ModuleConfig (task #3495)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "alt3/cakephp-swagger": "^1.0",
         "eluceo/ical": "^0.11.0",
         "friendsofcake/crud": "^4.3",
-        "qobo/cakephp-utils": "^1.0",
+        "qobo/cakephp-utils": "^2.0",
         "symfony/expression-language": "^3.1"
     },
     "require-dev": {

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -3,8 +3,7 @@ namespace CsvMigrations;
 
 use Cake\Core\Configure;
 use Cake\Utility\Inflector;
-use Qobo\Utils\Parser\Ini\Parser;
-use Qobo\Utils\PathFinder\ConfigPathFinder;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 trait ConfigurationTrait
 {
@@ -128,10 +127,8 @@ trait ConfigurationTrait
      */
     protected function _setConfiguration($tableName)
     {
-        $pathFinder = new ConfigPathFinder;
-        $path = $pathFinder->find(Inflector::camelize($tableName));
-        $parser = new Parser();
-        $this->_config = $parser->parseFromPath($path);
+        $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_MODULE, Inflector::camelize($tableName));
+        $this->_config = $mc->parse();
         // display field from configuration file
         if (isset($this->_config['table']['display_field']) && method_exists($this, 'displayField')) {
             $this->displayField($this->_config['table']['display_field']);

--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -13,8 +13,6 @@ use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use CsvMigrations\Panel;
 use CsvMigrations\PanelUtilTrait;
-use Qobo\Utils\Parser\Csv\ViewParser;
-use Qobo\Utils\PathFinder\ViewPathFinder;
 use \Exception;
 use \RuntimeException;
 
@@ -133,9 +131,8 @@ class CsvViewComponent extends Component
     {
         $result = [];
 
-        $pathFinder = new ViewPathFinder();
-        $path = $pathFinder->find($this->request->controller, $this->request->action);
-        $result = $this->_getFieldsFromCsv($path);
+        $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_VIEW, $this->request->controller, $this->request->action);
+        $result = $mc->parse();
 
         list($plugin, $model) = pluginSplit($this->_tableInstance->registryAlias());
         /*
@@ -151,23 +148,6 @@ class CsvViewComponent extends Component
         }
         $this->_controllerInstance->set('fields', $result);
         $this->_controllerInstance->set('_serialize', ['fields']);
-    }
-
-    /**
-     * Method that gets fields from a csv file
-     *
-     * @param  string $path   csv file path
-     * @return array          csv data
-     */
-    protected function _getFieldsFromCsv($path)
-    {
-        $result = [];
-        if (is_readable($path)) {
-            $parser = new ViewParser();
-            $result = $parser->parseFromPath($path);
-        }
-
-        return $result;
     }
 
     /**

--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -13,8 +13,9 @@ use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use CsvMigrations\Panel;
 use CsvMigrations\PanelUtilTrait;
-use \Exception;
-use \RuntimeException;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
+use Exception;
+use RuntimeException;
 
 /**
  * CsvView component

--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -13,8 +13,8 @@ use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use CsvMigrations\Panel;
 use CsvMigrations\PanelUtilTrait;
-use Qobo\Utils\ModuleConfig\ModuleConfig;
 use Exception;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 use RuntimeException;
 
 /**

--- a/src/CsvMigration.php
+++ b/src/CsvMigration.php
@@ -10,8 +10,7 @@ use CsvMigrations\FieldHandlers\DbField;
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;
 use Migrations\AbstractMigration;
 use Migrations\Table;
-use Qobo\Utils\Parser\Csv\MigrationParser;
-use Qobo\Utils\PathFinder\MigrationPathFinder;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 use RuntimeException;
 
 /**
@@ -86,7 +85,7 @@ class CsvMigration extends AbstractMigration
     {
         $this->_fhf = new FieldHandlerFactory();
         $this->_table = $table;
-        $this->_handleCsv($path);
+        $this->_handleCsv();
 
         return $this->_table;
     }
@@ -94,19 +93,13 @@ class CsvMigration extends AbstractMigration
     /**
      * Apply changes from the CSV file
      *
-     * @param string $path Path to the CSV file
      * @return void
      */
-    protected function _handleCsv($path = '')
+    protected function _handleCsv()
     {
         $tableName = Inflector::pluralize(Inflector::classify($this->_table->getName()));
-        if ('' === trim($path)) {
-            $pathFinder = new MigrationPathFinder;
-            $path = $pathFinder->find($tableName);
-        }
-
-        $parser = new MigrationParser();
-        $csvData = $parser->wrapFromPath($path);
+        $mc = new ModuleConfig(CONFIG_TYPE_MIGRATION, $tableName);
+        $csvData = $mc->parse();
         $csvData = array_merge($csvData, $this->_requiredFields);
 
         $tableFields = $this->_getTableFields();

--- a/src/Events/BaseViewListener.php
+++ b/src/Events/BaseViewListener.php
@@ -16,10 +16,7 @@ use CsvMigrations\FieldHandlers\CsvField;
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;
 use CsvMigrations\PrettifyTrait;
 use InvalidArgumentException;
-use Qobo\Utils\Parser\Csv\MigrationParser;
-use Qobo\Utils\Parser\Csv\ViewParser;
-use Qobo\Utils\PathFinder\MigrationPathFinder;
-use Qobo\Utils\PathFinder\ViewPathFinder;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 abstract class BaseViewListener implements EventListenerInterface
 {
@@ -97,11 +94,8 @@ abstract class BaseViewListener implements EventListenerInterface
         $result = [];
 
         try {
-            $pathFinder = new MigrationPathFinder;
-            $path = $pathFinder->find($request->controller);
-
-            $parser = new MigrationParser();
-            $result = $parser->wrapFromPath($path);
+            $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_MIGRATION, $request->controller);
+            $result = $mc->parse();
         } catch (InvalidArgumentException $e) {
             Log::error($e);
         }
@@ -127,11 +121,8 @@ abstract class BaseViewListener implements EventListenerInterface
         }
 
         try {
-            $pathFinder = new ViewPathFinder;
-            $path = $pathFinder->find($controller, $action);
-
-            $parser = new ViewParser();
-            $result = $parser->parseFromPath($path);
+            $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_VIEW, $controller, $action);
+            $result = $mc->parse();
         } catch (InvalidArgumentException $e) {
             Log::error($e);
         }

--- a/src/Events/ViewViewTabsListener.php
+++ b/src/Events/ViewViewTabsListener.php
@@ -11,8 +11,7 @@ use Cake\Utility\Inflector;
 use CsvMigrations\MigrationTrait;
 use CsvMigrations\Panel;
 use CsvMigrations\PanelUtilTrait;
-use Qobo\Utils\Parser\Csv\ViewParser;
-use Qobo\Utils\PathFinder\ViewPathFinder;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 class ViewViewTabsListener implements EventListenerInterface
 {
@@ -423,9 +422,8 @@ class ViewViewTabsListener implements EventListenerInterface
         }
 
         try {
-            $pathFinder = new ViewPathFinder;
-            $path = $pathFinder->find($tableName, $action);
-            $csvFields = $this->_getFieldsFromCsv($path);
+            $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_VIEW, $tableName, $action);
+            $csvFields = $mc->parse();
         } catch (Exception $e) {
             return $result;
         }
@@ -437,23 +435,6 @@ class ViewViewTabsListener implements EventListenerInterface
         $result = array_map(function ($v) {
             return $v[0];
         }, $csvFields);
-
-        return $result;
-    }
-
-    /**
-     * Method that gets fields from a csv file
-     *
-     * @param  string $path   csv file path
-     * @return array          csv data
-     */
-    protected function _getFieldsFromCsv($path)
-    {
-        $result = [];
-        if (is_readable($path)) {
-            $parser = new ViewParser();
-            $result = $parser->parseFromPath($path);
-        }
 
         return $result;
     }

--- a/src/FieldHandlers/BaseCsvListFieldHandler.php
+++ b/src/FieldHandlers/BaseCsvListFieldHandler.php
@@ -4,8 +4,7 @@ namespace CsvMigrations\FieldHandlers;
 use Cake\Collection\Collection;
 use Cake\Core\Configure;
 use CsvMigrations\FieldHandlers\BaseListFieldHandler;
-use Qobo\Utils\Parser\Csv\ListParser;
-use Qobo\Utils\PathFinder\ListPathFinder;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 /**
  * BaseCsvListFieldHandler
@@ -144,14 +143,12 @@ abstract class BaseCsvListFieldHandler extends BaseListFieldHandler
         }
         $listData = [];
         try {
-            $pathFinder = new ListPathFinder;
-            $path = $pathFinder->find($module, $listName);
-            $parser = new ListParser();
-            $listData = $parser->parseFromPath($path);
+            $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_LIST, $module, $listName);
+            $listData = $mc->parse();
         } catch (\Exception $e) {
             /* Do nothing.
              *
-             * ListPathFinder and ListParser check for the
+             * ModuleConfig checks for the
              * file to exist and to be readable and so on,
              * but here we do load lists recursively (for
              * sub-lists, etc), which might result in files

--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -12,8 +12,7 @@ use CsvMigrations\FieldHandlers\FieldHandlerInterface;
 use CsvMigrations\View\AppView;
 use Exception;
 use InvalidArgumentException;
-use Qobo\Utils\Parser\Ini\Parser as IniParser;
-use Qobo\Utils\PathFinder\FieldsPathFinder;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 use RuntimeException;
 
 /**
@@ -203,15 +202,14 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
         // set $options['label']
         $this->defaultOptions['label'] = $this->renderName();
 
-        $path = '';
+        $renderAs = '';
         try {
-            $pathFinder = new FieldsPathFinder;
-            $path = $pathFinder->find(Inflector::camelize($this->table->table()));
-        } catch (Exception $e) {
+            $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_FIELDS, Inflector::camelize($this->table->table()));
+            $config = $mc->parse();
+            $renderAs = empty($config[$this->field]['renderAs']) ? '' : $config[$this->field]['renderAs'];
+        } catch (\Exception $e) {
             //
         }
-        $parser = new IniParser;
-        $renderAs = $parser->getFieldsIniParams($path, $this->field, 'renderAs');
 
         if (!empty($renderAs)) {
             $this->defaultOptions['renderAs'] = $renderAs;
@@ -400,15 +398,14 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
     {
         $text = $this->field;
 
-        $path = '';
+        $label = '';
         try {
-            $pathFinder = new FieldsPathFinder;
-            $path = $pathFinder->find(Inflector::camelize($this->table->table()));
-        } catch (Exception $e) {
+            $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_FIELDS, Inflector::camelize($this->table->table()));
+            $config = $mc->parse();
+            $label = empty($config[$text]['label']) ? '' : $config[$text]['label'];
+        } catch (\Exception $e) {
             //
         }
-        $parser = new IniParser;
-        $label = $parser->getFieldsIniParams($path, $text, 'label');
         if ($label) {
             return $label;
         }
@@ -571,15 +568,14 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
         }
 
         if (!$result) {
-            $path = '';
+            $default = '';
             try {
-                $pathFinder = new FieldsPathFinder;
-                $path = $pathFinder->find(Inflector::camelize($this->table->table()));
-            } catch (Exception $e) {
+                $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_FIELDS, Inflector::camelize($this->table->table()));
+                $config = $mc->parse();
+                $default = empty($config[$field]['default']) ? '' : $config[$field]['default'];
+            } catch (\Exception $e) {
                 //
             }
-            $parser = new IniParser;
-            $default = $parser->getFieldsIniParams($path, $field, 'default');
             if (empty($default)) {
                 return $result;
             }

--- a/src/Shell/Task/CsvMigrationTask.php
+++ b/src/Shell/Task/CsvMigrationTask.php
@@ -6,7 +6,7 @@ use Cake\Filesystem\Folder;
 use Cake\Utility\Inflector;
 use Migrations\Shell\Task\MigrationTask;
 use Phinx\Util\Util;
-use Qobo\Utils\PathFinder\MigrationPathFinder;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 /**
  * CsvMigrations baking migration task, used to extend CakePHP's bake functionality.
@@ -126,8 +126,8 @@ class CsvMigrationTask extends MigrationTask
     {
         $tableName = Inflector::camelize($tableName);
 
-        $pathFinder = new MigrationPathFinder;
-        $path = $pathFinder->find($tableName);
+        $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_MIGRATION, $tableName);
+        $path = $mc->find();
 
         // Unit time stamp to YYYYMMDDhhmmss
         $result = date('YmdHis', filemtime($path));

--- a/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
@@ -1,12 +1,14 @@
 <?php
 namespace CsvMigrations\Test\TestCase\FieldHandlers;
 
+use Cake\Core\Configure;
 use CsvMigrations\FieldHandlers\BlobFieldHandler;
 use CsvMigrations\FieldHandlers\CsvField;
 use PHPUnit_Framework_TestCase;
 
 class BlobFieldHandlerTest extends PHPUnit_Framework_TestCase
 {
+    protected $dataDir;
     protected $table = 'Fields';
     protected $field = 'field_blob';
 
@@ -14,6 +16,8 @@ class BlobFieldHandlerTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $this->dataDir = dirname(dirname(__DIR__)) . DS . 'config' . DS . 'Modules' . DS;
+        Configure::write('CsvMigrations.modules.path', $this->dataDir);
         $this->fh = new BlobFieldHandler($this->table, $this->field);
     }
 

--- a/tests/TestCase/FieldHandlers/CsvFieldTest.php
+++ b/tests/TestCase/FieldHandlers/CsvFieldTest.php
@@ -4,8 +4,7 @@ namespace CsvMigrations\Test\TestCase\FieldHandlers;
 use Cake\Core\Configure;
 use CsvMigrations\FieldHandlers\CsvField;
 use PHPUnit_Framework_TestCase;
-use Qobo\Utils\Parser\Csv\MigrationParser;
-use Qobo\Utils\PathFinder\MigrationPathFinder;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 class CsvFieldTest extends PHPUnit_Framework_TestCase
 {
@@ -16,10 +15,8 @@ class CsvFieldTest extends PHPUnit_Framework_TestCase
         $dir = dirname(__DIR__) . DS . '..' . DS . 'data' . DS . 'Modules' . DS;
         Configure::write('CsvMigrations.modules.path', $dir);
 
-        $pf = new MigrationPathFinder();
-        $path = $pf->find('Foo');
-        $parser = new MigrationParser();
-        $this->csvData = $parser->wrapFromPath($path);
+        $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_MIGRATION, 'Foo');
+        $this->csvData = $mc->parse();
     }
 
     /**

--- a/tests/TestCase/FieldHandlers/FieldHandlerFactoryTest.php
+++ b/tests/TestCase/FieldHandlers/FieldHandlerFactoryTest.php
@@ -7,8 +7,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use CsvMigrations\FieldHandlers\CsvField;
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;
-use Qobo\Utils\Parser\Csv\MigrationParser;
-use Qobo\Utils\PathFinder\MigrationPathFinder;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 /**
  * Foo Entity.
@@ -82,10 +81,8 @@ class FieldHandlerFactoryTest extends TestCase
         $dir = dirname(__DIR__) . DS . '..' . DS . 'data' . DS . 'Modules' . DS;
         Configure::write('CsvMigrations.modules.path', $dir);
 
-        $pf = new MigrationPathFinder();
-        $path = $pf->find($this->tableName);
-        $parser = new MigrationParser();
-        $this->csvData = $parser->wrapFromPath($path);
+        $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_MIGRATION, $this->tableName);
+        $this->csvData = $mc->parse();
 
         $config = TableRegistry::exists($this->tableName)
             ? []

--- a/tests/config/Modules/Fields/config/fields.ini
+++ b/tests/config/Modules/Fields/config/fields.ini
@@ -1,0 +1,66 @@
+[field_blob]
+label="Blob field"
+
+[field_boolean]
+label="Boolean field"
+
+[field_date]
+label="Date field"
+
+[field_datetime]
+label="Datetime field"
+
+[field_dblist]
+label="Dblist field"
+
+[field_decimal]
+label="Decimal field"
+
+[field_email]
+label="Email field"
+
+[field_files]
+label="Files field"
+
+[field_images]
+label="Images field"
+
+[field_integer]
+label="Integer field"
+
+[field_list]
+label="List field"
+
+[field_metric]
+label="Metric field"
+
+[field_money]
+label="Money field"
+
+[field_phone]
+label="Phone field"
+
+[field_related]
+label="Related field"
+
+[field_reminder]
+label="Reminder field"
+
+[field_string]
+label="String field"
+
+[field_sublist]
+label="Sublist field"
+
+[field_text]
+label="Text field"
+
+[field_time]
+label="Time field"
+
+[field_url]
+label="Url field"
+
+[field_uuid]
+label="Uuid field"
+


### PR DESCRIPTION
Upgrades the dependency to [cakephp-utils v2+](https://github.com/QoboLtd/cakephp-utils/releases/tag/v2.0.0) and fixes all code references.