### PR TITLE
Empty value on select2 options (task #4000)

### DIFF
--- a/src/FieldHandlers/BaseRelatedFieldHandler.php
+++ b/src/FieldHandlers/BaseRelatedFieldHandler.php
@@ -84,6 +84,7 @@ abstract class BaseRelatedFieldHandler extends BaseFieldHandler
             'label' => $options['label'],
             'required' => $options['fieldDefinitions']->getRequired(),
             'value' => $data,
+            'options' => ['' => '', $data => $relatedProperties['dispFieldVal']],
             'relatedProperties' => $relatedProperties,
             'embedded' => !empty($options['embModal']),
             'icon' => $this->_getInputIcon($relatedProperties),

--- a/src/Template/Element/FieldHandlers/RelatedFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/RelatedFieldHandler/input.ctp
@@ -5,7 +5,7 @@
             <span class="fa fa-<?= $icon ?>"></span>
         </span>
         <?= $this->Form->input($name, [
-            'options' => [$value => $relatedProperties['dispFieldVal']],
+            'options' => $options,
             'label' => false,
             'id' => $field,
             'type' => $type,


### PR DESCRIPTION
Added empty value on `select2` options. This will reset the `select2` value to empty when clear button is pressed.