### PR TITLE
Magic/dynamic defaults (task #3567)

### DIFF
--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -130,8 +130,8 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
     {
         $this->setTable($table);
         $this->setField($field);
-        $this->setDefaultOptions();
         $this->setView($cakeView);
+        $this->setDefaultOptions();
     }
 
     /**


### PR DESCRIPTION
Default values set in configuration files can now be extended/overwritten on the application level, using the event listener.

Event name: `CsvMigrations.FieldHandler.DefaultValue`.