### PR TITLE
Module name in Migration Trait (task #3810)

### DIFF
--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -1,6 +1,7 @@
 <?php
 namespace CsvMigrations;
 
+use Cake\Core\App;
 use Cake\Core\Configure;
 use CsvMigrations\CsvMigrationsUtils;
 use CsvMigrations\FieldHandlers\CsvField;
@@ -65,10 +66,8 @@ trait MigrationTrait
 
         // Fetch definitions from CSV if cache is empty
         if (empty($result)) {
-            $moduleName = null;
-            if (is_callable([$this, 'alias'])) {
-                $moduleName = $this->alias();
-            }
+            $moduleName = App::shortName(get_class($this), 'Model/Table', 'Table');
+            list(, $moduleName) = pluginSplit($moduleName);
 
             $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_MIGRATION, $moduleName);
             $result = (array)json_decode(json_encode($mc->parse()), true);


### PR DESCRIPTION
Current logic for fetching current module name will fail in case the `getFieldsDefinitions()` method is called from an association's target table object because the table alias will be set to the association name instead of the current module name.
