### PR TITLE
Fix sql constraint violation errors (task #4178)

### DIFF
--- a/src/Event/ViewViewTabsListener.php
+++ b/src/Event/ViewViewTabsListener.php
@@ -316,11 +316,10 @@ class ViewViewTabsListener implements EventListenerInterface
                 $csvFields
             )
         );
+        $primaryKey = $this->_tableInstance->aliasField($this->_tableInstance->getPrimaryKey());
         $query = $this->_tableInstance->find('all', [
-            'conditions' => [$this->_tableInstance->primaryKey() => $request->params['pass'][0]],
-            'contain' => [
-                $assocName
-            ]
+            'conditions' => [$primaryKey => $request->params['pass'][0]],
+            'contain' => [$assocName]
         ]);
         $records = $query->first()->{$assocTableName};
         // store association name


### PR DESCRIPTION
Prefix `primary key` with table name to avoid SQL integrity constraint violation errors.