### PR TITLE
Avoid prefixes to auto-append to entity URL (task #4259)

### DIFF
--- a/src/Event/ModelAfterSaveListener.php
+++ b/src/Event/ModelAfterSaveListener.php
@@ -136,7 +136,7 @@ class ModelAfterSaveListener implements EventListenerInterface
         }
 
         // append link
-        $entityUrl = Router::url(['controller' => $table->table(), 'action' => 'view', $entity->id], true);
+        $entityUrl = Router::url(['prefix' => false, 'controller' => $table->table(), 'action' => 'view', $entity->id], true);
         $emailContent .= "\n\nSee more: " . $entityUrl;
 
         foreach ($emails as $email) {


### PR DESCRIPTION
Using Embedded forms via API controllers, automagically appends `api` prefix to URL builder.
In order to view the related record within ICS file, no prefixes are needed.