### PR TITLE
Import Functionality (task #2503)

### DIFF
--- a/config/Migrations/20170804172500_AddImportIdAndRowNumberUniqueIndexToImportResults.php
+++ b/config/Migrations/20170804172500_AddImportIdAndRowNumberUniqueIndexToImportResults.php
@@ -1,0 +1,19 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddImportIdAndRowNumberUniqueIndexToImportResults extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('import_results');
+        $table->addIndex(['import_id', 'row_number'], ['unique' => true]);
+        $table->update();
+    }
+}

--- a/src/Controller/Traits/ImportTrait.php
+++ b/src/Controller/Traits/ImportTrait.php
@@ -49,7 +49,8 @@ trait ImportTrait
 
         // PUT logic
         if ($this->request->is('put')) { // Import/mapping.ctp
-            $entity = $table->patchEntity($entity, ['options' => $this->request->data('options')]);
+            $options = ImportUtility::prepareOptions($this->request->data('options'));
+            $entity = $table->patchEntity($entity, ['options' => $options]);
             if ($table->save($entity)) {
                 return $this->redirect($this->request->here);
             } else {

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -101,18 +101,20 @@ class ImportShell extends Shell
      *
      * @param \CsvMigrations\Model\Entity\Import $import Import entity
      * @param int $count Progress count
-     * @return bool
+     * @return void
      */
     protected function createImportResults(Import $import, $count)
     {
         $progress = $this->helper('Progress');
         $progress->init();
-
-        if (0 >= $count) {
-            return false;
-        }
-
         $table = TableRegistry::get('CsvMigrations.ImportResults');
+
+        $query = $table->find('all')->where(['import_id' => $import->get('id')]);
+        $queryCount = $query->count();
+
+        if ($queryCount >= $count) {
+            return;
+        }
 
         $data = [
             'import_id' => $import->get('id'),

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -192,19 +192,21 @@ class ImportShell extends Shell
             $data['status'] = $table::STATUS_FAIL;
             $import = $table->patchEntity($import, $data);
             $result = $table->save($import);
-        } else {
-            // increase attempts count
-            $data['attempts'] = $import->get('attempts') + 1;
-            $import = $table->patchEntity($import, $data);
-            $table->save($import);
 
-            $this->_run($import, $count);
-
-            // mark import as completed
-            $data['status'] = $table::STATUS_COMPLETED;
-            $import = $table->patchEntity($import, $data);
-            $result = $table->save($import);
+            return $result;
         }
+
+        // increase attempts count
+        $data['attempts'] = $import->get('attempts') + 1;
+        $import = $table->patchEntity($import, $data);
+        $table->save($import);
+
+        $this->_run($import, $count);
+
+        // mark import as completed
+        $data['status'] = $table::STATUS_COMPLETED;
+        $import = $table->patchEntity($import, $data);
+        $result = $table->save($import);
 
         return $result;
     }

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -278,6 +278,8 @@ class ImportShell extends Shell
 
         // skip empty processed data
         if (empty($data)) {
+            $this->_importFail($importResult, 'Row has no data');
+
             return;
         }
 
@@ -452,7 +454,7 @@ class ImportShell extends Shell
      * Mark import result as failed.
      *
      * @param \CsvMigrations\Model\Entity\ImportResult $entity ImportResult entity
-     * @param mixed $errors Save errors
+     * @param mixed $errors Fail errors
      * @return bool
      */
     protected function _importFail(ImportResult $entity, $errors)
@@ -461,8 +463,8 @@ class ImportShell extends Shell
 
         $errors = json_encode($errors);
 
-        $message = printf($table::STATUS_FAIL_MESSAGE, $errors);
         $entity->set('status', $table::STATUS_FAIL);
+        $message = sprintf($table::STATUS_FAIL_MESSAGE, $errors);
         $entity->set('status_message', $message);
 
         return $table->save($entity);

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -65,14 +65,12 @@ class ImportShell extends Shell
             ]);
 
         if ($query->isEmpty()) {
-            $this->abort('No imports found.');
+            $this->abort('No imports found');
         }
 
         foreach ($query->all() as $import) {
             $this->out('Importing from file: ' . basename($import->get('filename')));
-            $this->hr();
 
-            $this->info('Preparing records ..');
             if (empty($import->get('options'))) {
                 $this->warn('Skipping, no mapping found for file:' . basename($import->get('filename')));
                 $this->hr();
@@ -90,7 +88,10 @@ class ImportShell extends Shell
             if ($table::STATUS_IN_PROGRESS === $import->get('status')) {
                 $this->_existingImport($table, $import, $count);
             }
+            $this->hr();
         }
+
+        $this->success('Import Completed');
 
         // unlock file
         $lock->unlock();
@@ -105,8 +106,6 @@ class ImportShell extends Shell
      */
     protected function createImportResults(Import $import, $count)
     {
-        $progress = $this->helper('Progress');
-        $progress->init();
         $table = TableRegistry::get('CsvMigrations.ImportResults');
 
         $query = $table->find('all')->where(['import_id' => $import->get('id')]);
@@ -123,9 +122,13 @@ class ImportShell extends Shell
             'model_name' => $import->get('model_name')
         ];
 
+        $progress = $this->helper('Progress');
+        $progress->init();
+
         $i = $queryCount + 1;
         $progressCount = $count - $queryCount;
 
+        $this->info('Preparing records ..');
         // set $i = 1 to skip header row
         for ($i; $i <= $count; $i++) {
             $data['row_number'] = $i;
@@ -220,10 +223,6 @@ class ImportShell extends Shell
      */
     protected function _run(Import $import, $count)
     {
-        $progress = $this->helper('Progress');
-        $progress->init();
-
-        $this->info('Importing records ..');
         // generate import results records
         $this->createImportResults($import, $count);
 
@@ -231,6 +230,10 @@ class ImportShell extends Shell
 
         $headers = ImportUtility::getUploadHeaders($import);
 
+        $progress = $this->helper('Progress');
+        $progress->init();
+
+        $this->info('Importing records ..');
         foreach ($reader as $index => $row) {
             // skip first csv row
             if (0 === $index) {

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -269,7 +269,7 @@ class ImportShell extends Shell
 
         // skip empty processed data
         if (empty($data)) {
-            continue;
+            return;
         }
 
         $entity = $table->newEntity();
@@ -278,7 +278,7 @@ class ImportShell extends Shell
         } catch (Exception $e) {
             $this->_importFail($importResult, $e->getMessage());
 
-            continue;
+            return;
         }
 
         if ($table->save($entity)) {

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -69,8 +69,6 @@ class ImportShell extends Shell
         }
 
         foreach ($query->all() as $import) {
-            $count = ImportUtility::getRowsCount($import);
-
             $this->out('Importing from file: ' . basename($import->get('filename')));
             $this->hr();
 
@@ -80,6 +78,8 @@ class ImportShell extends Shell
                 $this->hr();
                 continue;
             }
+
+            $count = ImportUtility::getRowsCount($import);
 
             // new import
             if ($table::STATUS_PENDING === $import->get('status')) {

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -266,7 +266,7 @@ class ImportShell extends Shell
         $importResult = $query->first();
 
         // skip successful imports
-        if ('Success' === $importResult->get('status')) {
+        if ($importTable::STATUS_SUCCESS === $importResult->get('status')) {
             return;
         }
 

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -74,8 +74,6 @@ class ImportShell extends Shell
             $this->hr();
 
             $this->info('Preparing records ..');
-            // skip if failed to generate import results records
-            if (!$this->createImportResults($import, $count)) {
                 continue;
             }
 
@@ -217,6 +215,8 @@ class ImportShell extends Shell
         $progress->init();
 
         $this->info('Importing records ..');
+        // generate import results records
+        $this->createImportResults($import, $count);
 
         $reader = Reader::createFromPath($import->filename, 'r');
 

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -60,7 +60,8 @@ class ImportShell extends Shell
         $query = $table->find('all')
             ->where([
                 'status IN' => [$table::STATUS_PENDING, $table::STATUS_IN_PROGRESS],
-                'options IS NOT' => null
+                'options IS NOT' => null,
+                'options !=' => '',
             ]);
 
         if ($query->isEmpty()) {
@@ -74,6 +75,9 @@ class ImportShell extends Shell
             $this->hr();
 
             $this->info('Preparing records ..');
+            if (empty($import->get('options'))) {
+                $this->warn('Skipping, no mapping found for file:' . basename($import->get('filename')));
+                $this->hr();
                 continue;
             }
 

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -123,8 +123,11 @@ class ImportShell extends Shell
             'model_name' => $import->get('model_name')
         ];
 
+        $i = $queryCount + 1;
+        $progressCount = $count - $queryCount;
+
         // set $i = 1 to skip header row
-        for ($i = 1; $i <= $count; $i++) {
+        for ($i; $i <= $count; $i++) {
             $data['row_number'] = $i;
 
             $entity = $table->newEntity();
@@ -132,12 +135,10 @@ class ImportShell extends Shell
 
             $table->save($entity);
 
-            $progress->increment(100 / $count);
+            $progress->increment(100 / $progressCount);
             $progress->draw();
         }
         $this->out(null);
-
-        return true;
     }
 
     /**

--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -134,6 +134,31 @@ class Import
     }
 
     /**
+     * Prepare import options by removing fields with empty mapping parameters.
+     *
+     * @param array $options Import options
+     * @return array
+     */
+    public static function prepareOptions(array $options)
+    {
+        $result = [];
+
+        if (empty($options['fields'])) {
+            return null;
+        }
+
+        foreach ($options['fields'] as $field => $params) {
+            if (empty($params['column']) && empty($params['default'])) {
+                continue;
+            }
+
+            $result[$field] = $params;
+        }
+
+        return $result;
+    }
+
+    /**
      * Get CSV file rows count.
      *
      * @param \CsvMigrations\Model\Entity\Import $entity Import entity

--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -152,7 +152,7 @@ class Import
                 continue;
             }
 
-            $result[$field] = $params;
+            $result['fields'][$field] = $params;
         }
 
         return $result;

--- a/tests/Fixture/ImportResultsFixture.php
+++ b/tests/Fixture/ImportResultsFixture.php
@@ -29,6 +29,7 @@ class ImportResultsFixture extends TestFixture
         'trashed' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+            'import_id' => ['type' => 'unique', 'columns' => ['import_id', 'row_number'], 'length' => []],
         ],
         '_options' => [
             'engine' => 'InnoDB',

--- a/tests/TestCase/Utility/FieldTest.php
+++ b/tests/TestCase/Utility/FieldTest.php
@@ -7,7 +7,7 @@ use CsvMigrations\FieldHandlers\CsvField;
 use CsvMigrations\Utility\Field;
 
 /**
- * Search\Utility Test Case
+ * CsvMigrations\Utility\Field Test Case
  */
 class FieldTest extends TestCase
 {


### PR DESCRIPTION
- Generated import results check (https://github.com/QoboLtd/cakephp-csv-migrations/commit/f3bdf50a27b7757bcb5347aa0dfac33e53febb48).
- Added logic for filtering out fields without mapping parameters.
- Skip import if mapping options are not set.
- Flag empty rows as failed, with appropriate status message.
- Add unique index for `import_id` and `row_number` columns.



