### PR TITLE
Removing type declaration for PHP5.x compatibility reasons

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -407,7 +407,7 @@ class Table extends BaseTable
      *
      * @return \Cake\ORM\Association $result object
      */
-    public function getAssociationObject(string $tableName, string $associationName)
+    public function getAssociationObject($tableName, $associationName)
     {
         $result = null;
         $tableName = Inflector::camelize($tableName);


### PR DESCRIPTION
`string` type declaration is breaking BC for PHP5.x