### PR TITLE
Batch IDs Event (task #812)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -306,7 +306,9 @@ class AppController extends BaseController
             $conditions = [$this->{$this->name}->getPrimaryKey() . ' IN' => $batchIds];
             // execute batch delete
             if ($this->{$this->name}->deleteAll($conditions)) {
-                $this->Flash->success(__('Selected records have been deleted.'));
+                $this->Flash->success(
+                    __(count($batchIds) . ' of ' . $batchIdsCount . ' selected records have been deleted.')
+                );
             } else {
                 $this->Flash->error(__('Selected records could not be deleted. Please, try again.'));
             }
@@ -325,7 +327,9 @@ class AppController extends BaseController
             $conditions = [$this->{$this->name}->getPrimaryKey() . ' IN' => $batchIds];
             // execute batch edit
             if ($this->{$this->name}->updateAll($fields, $conditions)) {
-                $this->Flash->success(__('Selected records have been updated.'));
+                $this->Flash->success(
+                    __(count($batchIds) . ' of ' . $batchIdsCount . ' selected records have been updated.')
+                );
             } else {
                 $this->Flash->error(__('Selected records could not be updated. Please, try again.'));
             }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -295,14 +295,14 @@ class AppController extends BaseController
 
         $redirectUrl = ['plugin' => $this->plugin, 'controller' => $this->name, 'action' => 'index'];
 
+        $batchIds = (array)$this->request->data('batch.ids');
+        if (empty($batchIds)) {
+            $this->Flash->error(__('No records selected.'));
+
+            return $this->redirect($redirectUrl);
+        }
+
         if ('delete' === $operation) {
-            $batchIds = (array)$this->request->data('batch.ids');
-            if (empty($batchIds)) {
-                $this->Flash->error(__('No records selected.'));
-
-                return $this->redirect($redirectUrl);
-            }
-
             $conditions = [$this->{$this->name}->getPrimaryKey() . ' IN' => $batchIds];
             // execute batch delete
             if ($this->{$this->name}->deleteAll($conditions)) {
@@ -315,13 +315,6 @@ class AppController extends BaseController
         }
 
         if ('edit' === $operation && (bool)$this->request->data('batch.execute')) {
-            $batchIds = (array)$this->request->data('batch.ids');
-            if (empty($batchIds)) {
-                $this->Flash->error(__('No records selected.'));
-
-                return $this->redirect($redirectUrl);
-            }
-
             $fields = (array)$this->request->data($this->name);
             if (empty($fields)) {
                 $this->Flash->error(__('Selected records could not be updated. No changes provided.'));

--- a/src/Event/EventName.php
+++ b/src/Event/EventName.php
@@ -22,6 +22,8 @@ class EventName extends Enum
     const API_LOOKUP_BEFORE_FIND = 'CsvMigrations.beforeLookup';
     const API_VIEW_AFTER_FIND = 'CsvMigrations.View.afterFind';
     const API_VIEW_BEFORE_FIND = 'CsvMigrations.View.beforeFind';
+    // Controller events
+    const BATCH_IDS = 'CsvMigrations.Batch.ids';
     // Field Handlers events
     const FIELD_HANDLER_DEFAULT_VALUE = 'CsvMigrations.FieldHandler.DefaultValue';
     // Menu elements events

--- a/tests/TestCase/Controller/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/ArticlesControllerTest.php
@@ -229,6 +229,7 @@ class ArticlesControllerTest extends IntegrationTestCase
 
         $this->post('/articles/batch/delete', $data);
         $this->assertResponseSuccess();
+        $this->assertSession('2 of 2 selected records have been deleted.', 'Flash.flash.0.message');
 
         $query = TableRegistry::get('Articles')->find('all');
         $this->assertTrue($query->isEmpty());
@@ -243,13 +244,28 @@ class ArticlesControllerTest extends IntegrationTestCase
 
     public function testBatchEdit()
     {
-        $this->post('/articles/batch/edit');
+        $data = [
+            'batch' => [
+                'ids' => [
+                    '00000000-0000-0000-0000-000000000001',
+                    '00000000-0000-0000-0000-000000000002'
+                ]
+            ]
+        ];
+        $this->post('/articles/batch/edit', $data);
         $this->assertResponseSuccess();
 
         $entity = $this->viewVariable('entity');
 
         $this->assertInstanceOf(Article::class, $entity);
         $this->assertTrue($entity->isNew());
+    }
+
+    public function testBatchEditNoIds()
+    {
+        $this->post('/articles/batch/edit');
+        $this->assertRedirect('/articles');
+        $this->assertSession('No records selected.', 'Flash.flash.0.message');
     }
 
     public function testBatchEditExecute()
@@ -269,7 +285,7 @@ class ArticlesControllerTest extends IntegrationTestCase
 
         $this->post('/articles/batch/edit', $data);
         $this->assertRedirect('/articles');
-        $this->assertSession('Selected records have been updated.', 'Flash.flash.0.message');
+        $this->assertSession('2 of 2 selected records have been updated.', 'Flash.flash.0.message');
 
         $query = TableRegistry::get('Articles')->find()->where(['id IN' => $data['batch']['ids']]);
         foreach ($query->all() as $entity) {


### PR DESCRIPTION
Broadcasting of batch IDs `Event` to allow application level handling and filtering of the IDs. One example is access permission check of the specified batch operation against the provided IDs.