### PR TITLE
Fixing deletion redirect (task #4622)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -226,9 +226,9 @@ class AppController extends BaseController
             $this->Flash->error(__('The record could not be deleted. Please, try again.'));
         }
 
-        if (!empty($this->referer())) {
-            $url = $this->referer();
-        } else {
+        $url = $this->referer();
+
+        if (false !== strpos($url, $id)) {
             $url = ['action' => 'index'];
         }
 


### PR DESCRIPTION
In case the records has been deleted the plugin will try to
redirect it to `controller/view/<entity-id>` page which automatically throws 404 error.