### PR TITLE
Fix for list type field value (task #4649)

### DIFF
--- a/src/FieldHandlers/BaseCsvListFieldHandler.php
+++ b/src/FieldHandlers/BaseCsvListFieldHandler.php
@@ -49,7 +49,7 @@ abstract class BaseCsvListFieldHandler extends BaseListFieldHandler
         $options = array_merge($this->defaultOptions, $this->fixOptions($options));
         $result = $this->_getFieldValueFromData($data);
 
-        if (empty($result)) {
+        if ('' === trim($result)) {
             return $result;
         }
 


### PR DESCRIPTION
Fixes issue with list type field label not rendering correctly when the field value is `0`.