### PR TITLE
Associations logic improvements (task #4839)

### DIFF
--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -145,7 +145,9 @@ trait MigrationTrait
     {
         $data = $this->_csvDataToCsvObj($this->_csvData(true));
 
-        $this->setFileAssociations($config, $data);
+        if (!empty($data[$config['table']])) {
+            $this->setFileAssociations($data[$config['table']]);
+        }
 
         $this->setFieldAssociations($config, $data);
     }
@@ -153,13 +155,12 @@ trait MigrationTrait
     /**
      * Set associations with FileStorage table.
      *
-     * @param array $config The configuration for the Table.
-     * @param array $data All modules csv fields.
+     * @param array $data Current module csv fields.
      * @return void
      */
-    protected function setFileAssociations(array $config, array $data)
+    protected function setFileAssociations(array $data)
     {
-        foreach ($data[$config['table']] as $fields) {
+        foreach ($data as $fields) {
             foreach ($fields as $field) {
                 // skip non file or image types
                 if (!in_array($field->getType(), ['files', 'images'])) {

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -141,52 +141,70 @@ trait MigrationTrait
      */
     protected function _setAssociationsFromCsv(array $config)
     {
-        $csvData = $this->_csvData(true);
-        $csvObjData = $this->_csvDataToCsvObj($csvData);
-        $csvFilteredData = $this->_csvDataFilter($csvObjData, $this->__assocIdentifiers);
+        $data = $this->_csvDataToCsvObj($this->_csvData(true));
 
-        //setting up files associations for FileStorage relation
-        foreach ($csvObjData as $csvModule => $fields) {
-            foreach ($fields as $csvObjField) {
-                if (!in_array($csvObjField->getType(), ['files', 'images'])) {
+        $this->setFileAssociations($config, $data);
+
+        $this->setFieldAssociations($config, $data);
+    }
+
+    /**
+     * Set associations with FileStorage table.
+     *
+     * @param array $config The configuration for the Table.
+     * @param array $data All modules csv fields.
+     * @return void
+     */
+    protected function setFileAssociations(array $config, array $data)
+    {
+        foreach ($data[$config['table']] as $fields) {
+            foreach ($fields as $field) {
+                // skip non file or image types
+                if (!in_array($field->getType(), ['files', 'images'])) {
                     continue;
                 }
-                if ($csvModule <> $config['table']) {
-                    continue;
-                }
-                $fieldName = $csvObjField->getName();
-                $assocName = CsvMigrationsUtils::createAssociationName('Burzum/FileStorage.FileStorage', $fieldName);
-                $this->hasMany($assocName, [
+
+                $name = CsvMigrationsUtils::createAssociationName('Burzum/FileStorage.FileStorage', $field->getName());
+                $this->hasMany($name, [
                     'className' => 'Burzum/FileStorage.FileStorage',
                     'foreignKey' => 'foreign_key',
                     'conditions' => [
                         'model' => $this->table(),
-                        'model_field' => $fieldName,
+                        'model_field' => $field->getName(),
                     ]
                 ]);
             }
         }
+    }
+    /**
+     * Set associations based on migration.csv related type fields.
+     *
+     * @param array $config The configuration for the Table.
+     * @param array $data All modules csv fields.
+     * @return void
+     */
+    protected function setFieldAssociations(array $config, array $data)
+    {
+        // filter data to include only related type fields.
+        $data = $this->_csvDataFilter($data, $this->__assocIdentifiers);
 
-        foreach ($csvFilteredData as $csvModule => $fields) {
-            foreach ($fields as $csvObjField) {
-                $assoccsvModule = $csvObjField->getAssocCsvModule();
-                $fieldName = $csvObjField->getName();
-
-                if ($config['table'] === $csvModule) {
-                    $assocName = CsvMigrationsUtils::createAssociationName($assoccsvModule, $fieldName);
+        foreach ($data as $module => $fields) {
+            foreach ($fields as $field) {
+                if ($module === $config['table']) {
+                    $name = CsvMigrationsUtils::createAssociationName($field->getAssocCsvModule(), $field->getName());
                     //Belongs to association of the curren running module.
-                    $this->belongsTo($assocName, [
-                        'className' => $assoccsvModule,
-                        'foreignKey' => $fieldName
+                    $this->belongsTo($name, [
+                        'className' => $field->getAssocCsvModule(),
+                        'foreignKey' => $field->getName()
                     ]);
                 }
 
-                if ($config['table'] === $assoccsvModule) {
+                if ($field->getAssocCsvModule() === $config['table']) {
                     //Foreignkey found in other module
-                    $assocName = CsvMigrationsUtils::createAssociationName($csvModule, $fieldName);
-                    $this->hasMany($assocName, [
-                        'className' => $csvModule,
-                        'foreignKey' => $fieldName
+                    $name = CsvMigrationsUtils::createAssociationName($module, $field->getName());
+                    $this->hasMany($name, [
+                        'className' => $module,
+                        'foreignKey' => $field->getName()
                     ]);
                 }
             }

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -188,11 +188,13 @@ trait MigrationTrait
      */
     protected function setFieldAssociations(array $config, array $data)
     {
-        // filter data to include only related type fields.
-        $data = $this->_csvDataFilter($data, $this->__assocIdentifiers);
-
         foreach ($data as $module => $fields) {
             foreach ($fields as $field) {
+                // skip non related type
+                if (!in_array($field->getType(), ['related'])) {
+                    continue;
+                }
+
                 // belongs-to association of the current module.
                 if ($module === $config['table']) {
                     $name = CsvMigrationsUtils::createAssociationName($field->getAssocCsvModule(), $field->getName());

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -121,12 +121,14 @@ trait MigrationTrait
      */
     protected function _setAssociationsFromConfig(array $config)
     {
-        $manyToMany = (array)$this->getConfig(ConfigurationTrait::$CONFIG_OPTION_MANY_TO_MANY_MODULES);
-        if (empty($manyToMany)) {
+        $mc = new ModuleConfig(ConfigType::MODULE(), $this->getRegistryAlias());
+        $config = $mc->parse();
+        $modules = $config->manyToMany->modules;
+        if (empty($modules)) {
             return;
         }
 
-        foreach ($manyToMany as $module) {
+        foreach ($modules as $module) {
             $this->belongsToMany($module, [
                 'className' => $module
             ]);

--- a/src/MigrationTrait.php
+++ b/src/MigrationTrait.php
@@ -192,17 +192,17 @@ trait MigrationTrait
 
         foreach ($data as $module => $fields) {
             foreach ($fields as $field) {
+                // belongs-to association of the current module.
                 if ($module === $config['table']) {
                     $name = CsvMigrationsUtils::createAssociationName($field->getAssocCsvModule(), $field->getName());
-                    //Belongs to association of the curren running module.
                     $this->belongsTo($name, [
                         'className' => $field->getAssocCsvModule(),
                         'foreignKey' => $field->getName()
                     ]);
                 }
 
+                // foreign key found in a related module.
                 if ($field->getAssocCsvModule() === $config['table']) {
-                    //Foreignkey found in other module
                     $name = CsvMigrationsUtils::createAssociationName($module, $field->getName());
                     $this->hasMany($name, [
                         'className' => $module,


### PR DESCRIPTION
- Split associations setter logic into smaller methods.
- Modified many-to-many associations setter logic to use `ModuleConfig` for fetching the relevant configuration, instead of using the `ConfigurationTrait` logic.