### PR TITLE
Field value from query string (task #4768)

### DIFF
--- a/src/Template/Element/Form/fields.ctp
+++ b/src/Template/Element/Form/fields.ctp
@@ -55,8 +55,12 @@ foreach ($options['fields'] as $panelName => $panelFields) : ?>
             $value = $options['entity']->get($field['name']);
             if (!$value) {
                 // allowing query params to define field values.
-                $value = $this->request->query($field['name']);
-                $value = $this->request->data($field['name']);
+                if ($this->request->query($field['name'])) {
+                    $value = $this->request->query($field['name']);
+                }
+                if ($this->request->data($field['name'])) {
+                    $value = $this->request->data($field['name']);
+                }
             }
 
             $input = $factory->renderInput($tableName, $field['name'], $value, $handlerOptions);


### PR DESCRIPTION
Currently, we set empty field value from query parameters and request data without checking if they are set. This causes the issue of a set query parameter getting overwritten by empty request data.