### PR TITLE
Replacing ctp templates with twig for baking (task #5116)

### DIFF
--- a/src/Template/Bake/Controller/Api/controller.twig
+++ b/src/Template/Bake/Controller/Api/controller.twig
@@ -1,4 +1,4 @@
-<?php
+{#
 /**
  * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  *
@@ -9,8 +9,17 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+#}
+<?php
 namespace App\Controller\Api;
 
-class <%= $name %>Controller extends AppController
+/**
+ * {{ name }} Controller
+ *
+{% if defaultModel %}
+ * @property \{{ defaultModel }} ${{ name }}
+{% endif %}
+ */
+class {{ name }}Controller extends AppController
 {
 }

--- a/src/Template/Bake/Controller/controller.twig
+++ b/src/Template/Bake/Controller/controller.twig
@@ -1,4 +1,4 @@
-<?php
+{#
 /**
  * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  *
@@ -9,10 +9,19 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+#}
+<?php
 namespace App\Controller;
 
 use CsvMigrations\Controller\AppController as BaseController;
 
-class <%= $name %>Controller extends BaseController
+/**
+ * {{ name }} Controller
+ *
+{% if defaultModel %}
+ * @property \{{ defaultModel }} ${{ name }}
+{% endif %}
+ */
+class {{ name }}Controller extends BaseController
 {
 }

--- a/src/Template/Bake/Model/entity.twig
+++ b/src/Template/Bake/Model/entity.twig
@@ -1,4 +1,4 @@
-<?php
+{#
 /**
  * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  *
@@ -9,11 +9,13 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+#}
+<?php
 namespace App\Model\Entity;
 
 use Cake\ORM\Entity;
 
-class <%= $name %> extends Entity
+class {{ name }} extends Entity
 {
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().

--- a/src/Template/Bake/Model/table.twig
+++ b/src/Template/Bake/Model/table.twig
@@ -1,4 +1,4 @@
-<?php
+{#
 /**
  * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  *
@@ -9,9 +9,11 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+#}
+<?php
 namespace App\Model\Table;
 
-class <%= $name %>Table extends AppTable
+class {{ name }}Table extends AppTable
 {
     /**
      * Initialize method
@@ -23,7 +25,7 @@ class <%= $name %>Table extends AppTable
     {
         parent::initialize($config);
 
-        $this->table('<%= $table %>');
+        $this->table('{{ table }}');
         $this->primaryKey('id');
 
         $this->addBehavior('Timestamp');

--- a/src/Template/Bake/csv_migration.twig
+++ b/src/Template/Bake/csv_migration.twig
@@ -1,4 +1,4 @@
-<?php
+{#
 /**
  * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  *
@@ -9,11 +9,13 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
+#}
+<?php
 use CsvMigrations\CsvMigration;
 
-class <%= $name %> extends CsvMigration
+class {{ name }} extends CsvMigration
 {
+    {#
     /**
      * Change Method.
      *
@@ -21,18 +23,19 @@ class <%= $name %> extends CsvMigration
      * http://docs.phinx.org/en/latest/migrations.html#the-change-method
      * @return void
      */
+    #}
     public function change()
     {
-        $table = $this->table('<%= $table%>');
+        $table = $this->table('{{ table }}');
         $table = $this->csv($table);
 
-        if (!$this->hasTable('<%= $table%>')) {
+        if (!$this->hasTable('{{ table }}')) {
             $table->create();
         } else {
             $table->update();
         }
 
-        $joinedTables = $this->joins('<%= $table%>');
+        $joinedTables = $this->joins('{{ table }}');
         if (!empty($joinedTables)) {
             foreach ($joinedTables as $joinedTable) {
                 $joinedTable->create();


### PR DESCRIPTION
Twig becomes default template language for baking.

Reference: https://github.com/cakephp/bake/releases/tag/1.5.0
  