### PR TITLE
Add Field Handler Setting class and empty list option

### DIFF
--- a/src/FieldHandlers/Provider/RenderInput/ListRenderer.php
+++ b/src/FieldHandlers/Provider/RenderInput/ListRenderer.php
@@ -11,6 +11,8 @@
  */
 namespace CsvMigrations\FieldHandlers\Provider\RenderInput;
 
+use CsvMigrations\FieldHandlers\Setting;
+
 /**
  * ListRenderer
  *
@@ -33,7 +35,7 @@ class ListRenderer extends AbstractRenderer
 
         $fieldName = $table->aliasField($field);
 
-        $selectOptions = ['' => ' -- Please choose -- '];
+        $selectOptions = ['' => Setting::EMPTY_OPTION_LABEL()];
 
         // if select options are not pre-defined
         if (empty($options['selectOptions'])) {

--- a/src/FieldHandlers/Provider/SearchOptions/ListSearchOptions.php
+++ b/src/FieldHandlers/Provider/SearchOptions/ListSearchOptions.php
@@ -11,6 +11,8 @@
  */
 namespace CsvMigrations\FieldHandlers\Provider\SearchOptions;
 
+use CsvMigrations\FieldHandlers\Setting;
+
 /**
  * ListSearchOptions
  *
@@ -38,7 +40,7 @@ class ListSearchOptions extends AbstractSearchOptions
         $listName = $options['fieldDefinitions']->getLimit();
         $listOptions = [];
 
-        $selectOptions = ['' => ' -- Please choose -- '];
+        $selectOptions = ['' => Setting::EMPTY_OPTION_LABEL()];
         $selectOptions += $selectListItems->provide($listName, $listOptions);
 
         $options['listItems'] = $selectOptions;

--- a/src/FieldHandlers/Setting.php
+++ b/src/FieldHandlers/Setting.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Field Handler Settings
+ */
+class Setting extends Enum
+{
+    /**
+     * Label to use for the empty option in dropdown lists
+     */
+    const EMPTY_OPTION_LABEL = ' -- Please choose -- ';
+}


### PR DESCRIPTION
Before the last refactoring of the field handlers, there was an
EMPTY_OPTION_LABEL constant defined in the BaseListFieldHandler
class, which was super handy in a variety of situations.

The cosntant was removed and temporarily replaced with hardcoded
options in different providers.  This commit fixes the temporary
removal by returning the constant.  However, since the class
does not exist anymore, we introduce a new Setting class in the
Field Handlers namespace, which can be used for storing all
common constants.