### PR TITLE
Replace DB_FIELD_TYPE constant with a method (task #5061)

### DIFF
--- a/src/FieldHandlers/BaseFieldHandler.php
+++ b/src/FieldHandlers/BaseFieldHandler.php
@@ -35,11 +35,6 @@ use RuntimeException;
 abstract class BaseFieldHandler implements FieldHandlerInterface
 {
     /**
-     * Default database field type
-     */
-    const DB_FIELD_TYPE = 'string';
-
-    /**
      * Flag for rendering value as is
      */
     const RENDER_PLAIN_VALUE = 'plain';
@@ -159,12 +154,13 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
     {
         $table = $this->config->getTable();
         $field = $this->config->getField();
+        $dbFieldType = $this->getDbFieldType($field);
 
         // set $options['fieldDefinitions']
         $stubFields = [
             $field => [
                 'name' => $field,
-                'type' => self::DB_FIELD_TYPE, // not static:: to preserve string
+                'type' => $dbFieldType,
             ],
         ];
         if (method_exists($table, 'getFieldsDefinitions') && is_callable([$table, 'getFieldsDefinitions'])) {
@@ -387,6 +383,23 @@ abstract class BaseFieldHandler implements FieldHandlerInterface
         $result = $fieldToDb->provide($csvField);
 
         return $result;
+    }
+
+    /**
+     * Get database field type
+     *
+     * @param string $field Field name
+     * @return string
+     */
+    public static function getDbFieldType($field)
+    {
+        // Temporary dummy configuration
+        $config = new static::$defaultConfigClass($field);
+        $dbFieldType = $config->getProvider('dbFieldType');
+        $dbFieldType = new $dbFieldType($config);
+        $dbFieldType = $dbFieldType->provide($field);
+
+        return $dbFieldType;
     }
 
     /**

--- a/src/FieldHandlers/BlobFieldHandler.php
+++ b/src/FieldHandlers/BlobFieldHandler.php
@@ -16,11 +16,6 @@ use Phinx\Db\Adapter\MysqlAdapter;
 class BlobFieldHandler extends BaseFieldHandler
 {
     /**
-     * Database field type
-     */
-    const DB_FIELD_TYPE = 'blob';
-
-    /**
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\BlobConfig';

--- a/src/FieldHandlers/BooleanFieldHandler.php
+++ b/src/FieldHandlers/BooleanFieldHandler.php
@@ -14,11 +14,6 @@ namespace CsvMigrations\FieldHandlers;
 class BooleanFieldHandler extends BaseFieldHandler
 {
     /**
-     * Database field type
-     */
-    const DB_FIELD_TYPE = 'boolean';
-
-    /**
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\BooleanConfig';

--- a/src/FieldHandlers/Config/BlobConfig.php
+++ b/src/FieldHandlers/Config/BlobConfig.php
@@ -24,6 +24,7 @@ class BlobConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\BlobDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\BlobFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',

--- a/src/FieldHandlers/Config/BooleanConfig.php
+++ b/src/FieldHandlers/Config/BooleanConfig.php
@@ -24,6 +24,7 @@ class BooleanConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\BooleanDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\BooleanFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\BooleanSearchOperators',

--- a/src/FieldHandlers/Config/Config.php
+++ b/src/FieldHandlers/Config/Config.php
@@ -60,6 +60,7 @@ class Config implements ConfigInterface
      */
     protected $requiredProviders = [
         'combinedFields',
+        'dbFieldType',
         'fieldValue',
         'fieldToDb',
         'searchOperators',

--- a/src/FieldHandlers/Config/DateConfig.php
+++ b/src/FieldHandlers/Config/DateConfig.php
@@ -24,6 +24,7 @@ class DateConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\DateDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\DateFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\TimeSearchOperators',

--- a/src/FieldHandlers/Config/DatetimeConfig.php
+++ b/src/FieldHandlers/Config/DatetimeConfig.php
@@ -24,6 +24,7 @@ class DatetimeConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\DatetimeDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\DatetimeFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\TimeSearchOperators',

--- a/src/FieldHandlers/Config/DblistConfig.php
+++ b/src/FieldHandlers/Config/DblistConfig.php
@@ -24,6 +24,7 @@ class DblistConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\ListFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\ListSearchOperators',

--- a/src/FieldHandlers/Config/DecimalConfig.php
+++ b/src/FieldHandlers/Config/DecimalConfig.php
@@ -24,6 +24,7 @@ class DecimalConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\DecimalDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\DecimalFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\NumberSearchOperators',

--- a/src/FieldHandlers/Config/EmailConfig.php
+++ b/src/FieldHandlers/Config/EmailConfig.php
@@ -24,6 +24,7 @@ class EmailConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\StringFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',

--- a/src/FieldHandlers/Config/FilesConfig.php
+++ b/src/FieldHandlers/Config/FilesConfig.php
@@ -24,6 +24,7 @@ class FilesConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\UuidDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\PrimaryKeyFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\RelatedFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\NullSearchOperators',

--- a/src/FieldHandlers/Config/HasManyConfig.php
+++ b/src/FieldHandlers/Config/HasManyConfig.php
@@ -24,6 +24,7 @@ class HasManyConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\UuidDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\RelatedFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\NullSearchOperators',

--- a/src/FieldHandlers/Config/ImagesConfig.php
+++ b/src/FieldHandlers/Config/ImagesConfig.php
@@ -24,6 +24,7 @@ class ImagesConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\UuidDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\PrimaryKeyFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\RelatedFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\NullSearchOperators',

--- a/src/FieldHandlers/Config/IntegerConfig.php
+++ b/src/FieldHandlers/Config/IntegerConfig.php
@@ -24,6 +24,7 @@ class IntegerConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\IntegerDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\IntegerFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\NumberSearchOperators',

--- a/src/FieldHandlers/Config/ListConfig.php
+++ b/src/FieldHandlers/Config/ListConfig.php
@@ -24,6 +24,7 @@ class ListConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\ListFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\ListSearchOperators',

--- a/src/FieldHandlers/Config/MetricConfig.php
+++ b/src/FieldHandlers/Config/MetricConfig.php
@@ -24,6 +24,7 @@ class MetricConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\MetricCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\CombinedFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\NullSearchOperators',

--- a/src/FieldHandlers/Config/MoneyConfig.php
+++ b/src/FieldHandlers/Config/MoneyConfig.php
@@ -24,6 +24,7 @@ class MoneyConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\MoneyCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\CombinedFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\NullSearchOperators',

--- a/src/FieldHandlers/Config/PhoneConfig.php
+++ b/src/FieldHandlers/Config/PhoneConfig.php
@@ -24,6 +24,7 @@ class PhoneConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\StringFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',

--- a/src/FieldHandlers/Config/RelatedConfig.php
+++ b/src/FieldHandlers/Config/RelatedConfig.php
@@ -24,6 +24,7 @@ class RelatedConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\UuidDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\RelatedFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\RelatedSearchOperators',

--- a/src/FieldHandlers/Config/StringConfig.php
+++ b/src/FieldHandlers/Config/StringConfig.php
@@ -24,6 +24,7 @@ class StringConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\StringFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',

--- a/src/FieldHandlers/Config/SublistConfig.php
+++ b/src/FieldHandlers/Config/SublistConfig.php
@@ -24,6 +24,7 @@ class SublistConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\ListFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\ListSearchOperators',

--- a/src/FieldHandlers/Config/TextConfig.php
+++ b/src/FieldHandlers/Config/TextConfig.php
@@ -24,6 +24,7 @@ class TextConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\TextDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\TextFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',

--- a/src/FieldHandlers/Config/TimeConfig.php
+++ b/src/FieldHandlers/Config/TimeConfig.php
@@ -24,6 +24,7 @@ class TimeConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\TimeDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\TimeFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\TimeSearchOperators',

--- a/src/FieldHandlers/Config/UrlConfig.php
+++ b/src/FieldHandlers/Config/UrlConfig.php
@@ -24,6 +24,7 @@ class UrlConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\StringFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',

--- a/src/FieldHandlers/Config/UuidConfig.php
+++ b/src/FieldHandlers/Config/UuidConfig.php
@@ -24,6 +24,7 @@ class UuidConfig extends FixedConfig
      */
     protected $providers = [
         'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\UuidDbFieldType',
         'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
         'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\UuidFieldToDb',
         'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\NullSearchOperators',

--- a/src/FieldHandlers/DateFieldHandler.php
+++ b/src/FieldHandlers/DateFieldHandler.php
@@ -14,11 +14,6 @@ namespace CsvMigrations\FieldHandlers;
 class DateFieldHandler extends BaseFieldHandler
 {
     /**
-     * Database field type
-     */
-    const DB_FIELD_TYPE = 'date';
-
-    /**
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\DateConfig';

--- a/src/FieldHandlers/DatetimeFieldHandler.php
+++ b/src/FieldHandlers/DatetimeFieldHandler.php
@@ -14,11 +14,6 @@ namespace CsvMigrations\FieldHandlers;
 class DatetimeFieldHandler extends BaseFieldHandler
 {
     /**
-     * Database field type
-     */
-    const DB_FIELD_TYPE = 'datetime';
-
-    /**
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\DatetimeConfig';

--- a/src/FieldHandlers/DecimalFieldHandler.php
+++ b/src/FieldHandlers/DecimalFieldHandler.php
@@ -14,11 +14,6 @@ namespace CsvMigrations\FieldHandlers;
 class DecimalFieldHandler extends BaseFieldHandler
 {
     /**
-     * Database field type
-     */
-    const DB_FIELD_TYPE = 'decimal';
-
-    /**
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\DecimalConfig';

--- a/src/FieldHandlers/FilesFieldHandler.php
+++ b/src/FieldHandlers/FilesFieldHandler.php
@@ -17,9 +17,4 @@ class FilesFieldHandler extends BaseFieldHandler
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\FilesConfig';
-
-    /**
-     * Field type
-     */
-    const DB_FIELD_TYPE = 'uuid';
 }

--- a/src/FieldHandlers/HasManyFieldHandler.php
+++ b/src/FieldHandlers/HasManyFieldHandler.php
@@ -17,9 +17,4 @@ class HasManyFieldHandler extends BaseFieldHandler
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\HasManyConfig';
-
-    /**
-     * Field type
-     */
-    const DB_FIELD_TYPE = 'uuid';
 }

--- a/src/FieldHandlers/ImagesFieldHandler.php
+++ b/src/FieldHandlers/ImagesFieldHandler.php
@@ -17,9 +17,4 @@ class ImagesFieldHandler extends BaseFieldHandler
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\ImagesConfig';
-
-    /**
-     * Field type
-     */
-    const DB_FIELD_TYPE = 'uuid';
 }

--- a/src/FieldHandlers/IntegerFieldHandler.php
+++ b/src/FieldHandlers/IntegerFieldHandler.php
@@ -14,11 +14,6 @@ namespace CsvMigrations\FieldHandlers;
 class IntegerFieldHandler extends BaseFieldHandler
 {
     /**
-     * Database field type
-     */
-    const DB_FIELD_TYPE = 'integer';
-
-    /**
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\IntegerConfig';

--- a/src/FieldHandlers/Provider/DbFieldType/AbstractDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/AbstractDbFieldType.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+use CsvMigrations\FieldHandlers\Provider\AbstractProvider;
+
+/**
+ * AbstractDbFieldType
+ *
+ * Abstract DbFieldType provides the default functionality
+ * for fetching the field's database type.
+ */
+abstract class AbstractDbFieldType extends AbstractProvider
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'string';
+
+    /**
+     * Provide database field type
+     *
+     * @param mixed $data Data to use for provision
+     * @param array $options Options to use for provision
+     * @return string
+     */
+    public function provide($data = null, array $options = [])
+    {
+        return $this->dbFieldType;
+    }
+}

--- a/src/FieldHandlers/Provider/DbFieldType/BlobDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/BlobDbFieldType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * BlobDbFieldType
+ *
+ * Blob database field type.
+ */
+class BlobDbFieldType extends AbstractDbFieldType
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'blob';
+}

--- a/src/FieldHandlers/Provider/DbFieldType/BooleanDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/BooleanDbFieldType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * BooleanDbFieldType
+ *
+ * Boolean database field type.
+ */
+class BooleanDbFieldType extends AbstractDbFieldType
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'boolean';
+}

--- a/src/FieldHandlers/Provider/DbFieldType/DateDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/DateDbFieldType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * DateDbFieldType
+ *
+ * Date database field type.
+ */
+class DateDbFieldType extends AbstractDbFieldType
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'date';
+}

--- a/src/FieldHandlers/Provider/DbFieldType/DatetimeDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/DatetimeDbFieldType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * DatetimeDbFieldType
+ *
+ * Datetime database field type.
+ */
+class DatetimeDbFieldType extends AbstractDbFieldType
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'datetime';
+}

--- a/src/FieldHandlers/Provider/DbFieldType/DecimalDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/DecimalDbFieldType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * DecimalDbFieldType
+ *
+ * Decimal database field type.
+ */
+class DecimalDbFieldType extends AbstractDbFieldType
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'decimal';
+}

--- a/src/FieldHandlers/Provider/DbFieldType/IntegerDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/IntegerDbFieldType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * IntegerDbFieldType
+ *
+ * Integer database field type.
+ */
+class IntegerDbFieldType extends AbstractDbFieldType
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'integer';
+}

--- a/src/FieldHandlers/Provider/DbFieldType/StringDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/StringDbFieldType.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * StringDbFieldType
+ *
+ * String database field type.
+ */
+class StringDbFieldType extends AbstractDbFieldType
+{
+}

--- a/src/FieldHandlers/Provider/DbFieldType/TextDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/TextDbFieldType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * TextDbFieldType
+ *
+ * Text database field type.
+ */
+class TextDbFieldType extends AbstractDbFieldType
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'text';
+}

--- a/src/FieldHandlers/Provider/DbFieldType/TimeDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/TimeDbFieldType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * TimeDbFieldType
+ *
+ * Time database field type.
+ */
+class TimeDbFieldType extends AbstractDbFieldType
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'time';
+}

--- a/src/FieldHandlers/Provider/DbFieldType/UuidDbFieldType.php
+++ b/src/FieldHandlers/Provider/DbFieldType/UuidDbFieldType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\DbFieldType;
+
+/**
+ * UuidDbFieldType
+ *
+ * Uuid database field type.
+ */
+class UuidDbFieldType extends AbstractDbFieldType
+{
+    /**
+     * @var string $dbFieldType Database field type
+     */
+    protected $dbFieldType = 'uuid';
+}

--- a/src/FieldHandlers/Provider/SearchOptions/CombinedSearchOptions.php
+++ b/src/FieldHandlers/Provider/SearchOptions/CombinedSearchOptions.php
@@ -35,8 +35,8 @@ class CombinedSearchOptions extends AbstractSearchOptions
 
         $view = $this->config->getView();
         foreach ($combinedFields as $suffix => $fieldOptions) {
-            $options['fieldDefinitions']->setType($fieldOptions['handler']::DB_FIELD_TYPE);
             $fieldName = $this->config->getField() . '_' . $suffix;
+            $options['fieldDefinitions']->setType($fieldOptions['handler']::getDbFieldType($fieldName));
             $handler = new $fieldOptions['handler']($this->config->getTable(), $fieldName, $view);
             $fieldOptions = $handler->getSearchOptions($options);
             if (!empty($fieldOptions)) {

--- a/src/FieldHandlers/RelatedFieldHandler.php
+++ b/src/FieldHandlers/RelatedFieldHandler.php
@@ -19,11 +19,6 @@ class RelatedFieldHandler extends BaseFieldHandler
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\RelatedConfig';
 
     /**
-     * Field type
-     */
-    const DB_FIELD_TYPE = 'uuid';
-
-    /**
      * Flag for rendering value as is
      */
     const RENDER_PLAIN_VALUE = 'relatedPlain';

--- a/src/FieldHandlers/TextFieldHandler.php
+++ b/src/FieldHandlers/TextFieldHandler.php
@@ -16,11 +16,6 @@ use Phinx\Db\Adapter\MysqlAdapter;
 class TextFieldHandler extends BaseFieldHandler
 {
     /**
-     * Database field type
-     */
-    const DB_FIELD_TYPE = 'text';
-
-    /**
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\TextConfig';

--- a/src/FieldHandlers/TimeFieldHandler.php
+++ b/src/FieldHandlers/TimeFieldHandler.php
@@ -14,11 +14,6 @@ namespace CsvMigrations\FieldHandlers;
 class TimeFieldHandler extends BaseFieldHandler
 {
     /**
-     * Database field type
-     */
-    const DB_FIELD_TYPE = 'time';
-
-    /**
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\TimeConfig';

--- a/src/FieldHandlers/UuidFieldHandler.php
+++ b/src/FieldHandlers/UuidFieldHandler.php
@@ -17,9 +17,4 @@ class UuidFieldHandler extends BaseFieldHandler
      * @var string $defaultConfigClass Config class to use as default
      */
     protected static $defaultConfigClass = '\\CsvMigrations\\FieldHandlers\\Config\\UuidConfig';
-
-    /**
-     * Field type
-     */
-    const DB_FIELD_TYPE = 'uuid';
 }

--- a/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/BlobFieldHandlerTest.php
@@ -55,7 +55,7 @@ class BlobFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(BlobFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(BlobFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('blob', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertGreaterThan(100000000, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/BooleanFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/BooleanFieldHandlerTest.php
@@ -46,7 +46,7 @@ class BooleanFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(BooleanFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(BooleanFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('boolean', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/Config/ConfigTest.php
+++ b/tests/TestCase/FieldHandlers/Config/ConfigTest.php
@@ -24,6 +24,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             [
                 [
                     'combinedFields' => true,
+                    'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
                     'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
                     'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\StringFieldToDb',
                     'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',
@@ -38,6 +39,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             [
                 [
                     'combinedFields' => '\\StdClass',
+                    'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
                     'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
                     'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\StringFieldToDb',
                     'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',
@@ -52,6 +54,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             [
                 [
                     'combinedFields' => '\\Foo\\Bar\\No\\Exist',
+                    'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
                     'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
                     'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\StringFieldToDb',
                     'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',
@@ -67,6 +70,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             [
                 [
                     'combinedFields' => ' ',
+                    'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
                     'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
                     'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\StringFieldToDb',
                     'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',
@@ -86,6 +90,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             [
                 [
                     'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+                    'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
                     'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
                     'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\StringFieldToDb',
                     'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',

--- a/tests/TestCase/FieldHandlers/DateFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DateFieldHandlerTest.php
@@ -36,7 +36,7 @@ class DateFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(DateFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(DateFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('date', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/DatetimeFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DatetimeFieldHandlerTest.php
@@ -36,7 +36,7 @@ class DatetimeFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(DatetimeFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(DatetimeFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('datetime', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/DblistFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DblistFieldHandlerTest.php
@@ -35,7 +35,7 @@ class DblistFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(DblistFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(DblistFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('string', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertEquals(255, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/DecimalFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DecimalFieldHandlerTest.php
@@ -35,7 +35,7 @@ class DecimalFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(DecimalFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(DecimalFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('decimal', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
 
         $options = $result[$this->field]->getOptions();

--- a/tests/TestCase/FieldHandlers/EmailFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/EmailFieldHandlerTest.php
@@ -35,7 +35,7 @@ class EmailFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(EmailFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(EmailFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('string', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertEquals(255, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/FilesFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/FilesFieldHandlerTest.php
@@ -35,7 +35,7 @@ class FilesFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(FilesFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(FilesFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('uuid', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/HasManyFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/HasManyFieldHandlerTest.php
@@ -35,7 +35,7 @@ class HasManyFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(HasManyFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(HasManyFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('uuid', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/ImagesFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/ImagesFieldHandlerTest.php
@@ -35,7 +35,7 @@ class ImagesFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(ImagesFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(ImagesFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('uuid', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/IntegerFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/IntegerFieldHandlerTest.php
@@ -59,7 +59,7 @@ class IntegerFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(IntegerFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(IntegerFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('integer', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/ListFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/ListFieldHandlerTest.php
@@ -150,7 +150,7 @@ class ListFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(ListFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(ListFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('string', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertEquals(255, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/MetricFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/MetricFieldHandlerTest.php
@@ -82,7 +82,7 @@ class MetricFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$fieldName]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$fieldName], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(DecimalFieldHandler::DB_FIELD_TYPE, $result[$fieldName]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(DecimalFieldHandler::getDbFieldType($fieldName), $result[$fieldName]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('decimal', $result[$fieldName]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
 
         $fieldName = $this->field . '_' . 'unit';
@@ -90,7 +90,7 @@ class MetricFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$fieldName]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$fieldName], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(ListFieldHandler::DB_FIELD_TYPE, $result[$fieldName]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(ListFieldHandler::getDbFieldType($fieldName), $result[$fieldName]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('string', $result[$fieldName]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertEquals(255, $result[$fieldName]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/MoneyFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/MoneyFieldHandlerTest.php
@@ -82,7 +82,7 @@ class MoneyFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$fieldName]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$fieldName], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(DecimalFieldHandler::DB_FIELD_TYPE, $result[$fieldName]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(DecimalFieldHandler::getDbFieldType($fieldName), $result[$fieldName]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('decimal', $result[$fieldName]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
 
         $fieldName = $this->field . '_' . 'currency';
@@ -90,7 +90,7 @@ class MoneyFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$fieldName]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$fieldName], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(ListFieldHandler::DB_FIELD_TYPE, $result[$fieldName]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(ListFieldHandler::getDbFieldType($fieldName), $result[$fieldName]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('string', $result[$fieldName]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertEquals(255, $result[$fieldName]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/PhoneFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/PhoneFieldHandlerTest.php
@@ -35,7 +35,7 @@ class PhoneFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(PhoneFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(PhoneFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('string', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertEquals(255, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
@@ -104,7 +104,7 @@ class RelatedFieldHandlerTest extends TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(RelatedFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(RelatedFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('uuid', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/ReminderFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/ReminderFieldHandlerTest.php
@@ -36,7 +36,7 @@ class ReminderFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(ReminderFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(ReminderFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('datetime', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/StringFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/StringFieldHandlerTest.php
@@ -36,7 +36,7 @@ class StringFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(StringFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(StringFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('string', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertEquals(255, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/SublistFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/SublistFieldHandlerTest.php
@@ -67,7 +67,7 @@ class SublistFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(SublistFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(SublistFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('string', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertEquals(255, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/TextFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/TextFieldHandlerTest.php
@@ -35,7 +35,7 @@ class TextFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(TextFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(TextFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('text', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertGreaterThan(100000000, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
@@ -37,7 +37,7 @@ class TimeFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(TimeFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(TimeFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('time', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 

--- a/tests/TestCase/FieldHandlers/UrlFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/UrlFieldHandlerTest.php
@@ -35,7 +35,7 @@ class UrlFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(UrlFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(UrlFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('string', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
         $this->assertEquals(255, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
     }

--- a/tests/TestCase/FieldHandlers/UuidFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/UuidFieldHandlerTest.php
@@ -35,7 +35,7 @@ class UuidFieldHandlerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
         $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
 
-        $this->assertEquals(UuidFieldHandler::DB_FIELD_TYPE, $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals(UuidFieldHandler::getDbFieldType($this->field), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
         $this->assertEquals('uuid', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
     }
 


### PR DESCRIPTION
Replace `DB_FIELD_TYPE` constant in field handler classes, with the call to `getDbFieldType()` public static method call in `BaseFieldHandler` class, and a set of `DbFieldType` providers.