### PR TITLE
Correct namespaces for API Controller template (task #5385) 

### DIFF
--- a/src/Template/Bake/Controller/Api/controller.twig
+++ b/src/Template/Bake/Controller/Api/controller.twig
@@ -11,7 +11,7 @@
  */
 #}
 <?php
-namespace App\Controller\Api;
+namespace {{namespace}};
 
 /**
  * {{ name }} Controller

--- a/src/Template/Bake/csv_migration.twig
+++ b/src/Template/Bake/csv_migration.twig
@@ -15,7 +15,6 @@ use CsvMigrations\CsvMigration;
 
 class {{ name }} extends CsvMigration
 {
-    {#
     /**
      * Change Method.
      *
@@ -23,7 +22,6 @@ class {{ name }} extends CsvMigration
      * http://docs.phinx.org/en/latest/migrations.html#the-change-method
      * @return void
      */
-    #}
     public function change()
     {
         $table = $this->table('{{ table }}');


### PR DESCRIPTION
As nested API versioning was introduced in `qobo/cakephp-utils` (v6.8.2) and `project-template-cakephp`, twig template for baking csv modules had to be adjusted.

As a default behaviour, `cake bake csv_module` will be generaing API controller based on most recent API version in the corresponding directory.