### PR TITLE
Replace box-solid style with box-primary

### DIFF
--- a/src/Template/DblistItems/add.ctp
+++ b/src/Template/DblistItems/add.ctp
@@ -20,7 +20,7 @@
 <section class="content">
     <div class="row">
         <div class="col-md-6">
-            <div class="box box-solid">
+            <div class="box box-primary">
                 <div class="box-header with-border">
                     <h3 class="box-title"><?= __d('CsvMigrations', 'Details') ?></h3>
                 </div>

--- a/src/Template/DblistItems/edit.ctp
+++ b/src/Template/DblistItems/edit.ctp
@@ -20,7 +20,7 @@
 <section class="content">
     <div class="row">
         <div class="col-md-6">
-            <div class="box box-solid">
+            <div class="box box-primary">
                 <div class="box-header with-border">
                     <h3 class="box-title"><?= __d('CsvMigrations', 'Details') ?></h3>
                 </div>

--- a/src/Template/DblistItems/index.ctp
+++ b/src/Template/DblistItems/index.ctp
@@ -40,7 +40,7 @@ $factory = new FieldHandlerFactory($this);
     </div>
 </section>
 <section class="content">
-    <div class="box box-solid">
+    <div class="box box-primary">
         <div class="box-body table-responsive">
             <table class="table table-hover table-condensed table-vertical-align">
                 <thead>

--- a/src/Template/Dblists/add.ctp
+++ b/src/Template/Dblists/add.ctp
@@ -20,7 +20,7 @@
 <section class="content">
     <div class="row">
         <div class="col-md-6">
-            <div class="box box-solid">
+            <div class="box box-primary">
                 <div class="box-header with-border">
                     <h3 class="box-title"><?= __('Details') ?></h3>
                 </div>

--- a/src/Template/Dblists/edit.ctp
+++ b/src/Template/Dblists/edit.ctp
@@ -20,7 +20,7 @@
 <section class="content">
     <div class="row">
         <div class="col-md-6">
-            <div class="box box-solid">
+            <div class="box box-primary">
                 <div class="box-header with-border">
                     <h3 class="box-title"><?= __('Details') ?></h3>
                 </div>

--- a/src/Template/Dblists/index.ctp
+++ b/src/Template/Dblists/index.ctp
@@ -52,7 +52,7 @@ echo $this->Html->scriptBlock(
     </div>
 </section>
 <section class="content">
-    <div class="box box-solid">
+    <div class="box box-primary">
         <div class="box-body">
             <table class="table table-hover table-condensed table-vertical-align table-datatable">
                 <thead>

--- a/src/Template/Element/Form/fields.ctp
+++ b/src/Template/Element/Form/fields.ctp
@@ -17,7 +17,7 @@ $factory = new FieldHandlerFactory($this);
 $embeddedDirty = false;
 
 foreach ($options['fields'] as $panelName => $panelFields) : ?>
-<div class="box box-solid" data-provide="dynamic-panel">
+<div class="box box-primary" data-provide="dynamic-panel">
     <div class="box-header with-border">
         <h3 class="box-title" data-title="dynamic-panel-title"><?= $panelName ?></h3>
     </div>

--- a/src/Template/Element/View/index.ctp
+++ b/src/Template/Element/View/index.ctp
@@ -149,7 +149,7 @@ if (empty($options['title'])) {
     </div>
 </section>
 <section class="content">
-    <div class="box box-solid">
+    <div class="box box-primary">
         <div class="box-body">
             <div class="table-responsive">
                 <table class="table table-hover table-condensed table-vertical-align table-datatable" width="100%">

--- a/src/Template/Element/View/view.ctp
+++ b/src/Template/Element/View/view.ctp
@@ -79,7 +79,7 @@ foreach ($options['fields'] as $panelName => $panelFields) : ?>
         $panelName = Inflector::singularize(Inflector::humanize($this->name)) . ': ' . $panelName;
     }
     ?>
-    <div class="box box-solid">
+    <div class="box box-primary">
         <div class="box-header with-border">
             <h3 class="box-title"><?= $panelName; ?></h3>
             <div class="box-tools pull-right">

--- a/src/Template/Import/mapping.ctp
+++ b/src/Template/Import/mapping.ctp
@@ -36,7 +36,7 @@ foreach ($headers as $header) {
 <section class="content">
     <div class="row">
         <div class="col-md-10 col-lg-8">
-            <div class="box box-solid">
+            <div class="box box-primary">
                 <div class="box-body">
                 <?= $this->Form->create($import) ?>
                 <div class="visible-md visible-lg text-center">

--- a/src/Template/Import/progress.ctp
+++ b/src/Template/Import/progress.ctp
@@ -95,7 +95,7 @@ if (100 === (int)$percent) {
 <section class="content">
     <div class="row">
         <div class="col-lg-6">
-            <div class="box box-solid">
+            <div class="box box-primary">
                 <div class="box-header with-border">
                     <h3 class="box-title">
                         <?= __('Import progress') ?>
@@ -144,7 +144,7 @@ if (100 === (int)$percent) {
             </div>
         </div>
     </div>
-    <div class="box box-solid">
+    <div class="box box-primary">
         <div class="box-body">
             <table id="progress-table" class="table table-hover table-condensed table-vertical-align" width="100%">
                 <thead>

--- a/src/Template/Import/upload.ctp
+++ b/src/Template/Import/upload.ctp
@@ -29,7 +29,7 @@ $statusLabels = [
 <section class="content">
     <div class="row">
         <div class="col-md-6">
-            <div class="box box-solid">
+            <div class="box box-primary">
                 <div class="box-header with-border">
                     <h3 class="box-title">
                         <?= __('File upload') ?>
@@ -50,7 +50,7 @@ $statusLabels = [
     <?php if (!$existingImports->isEmpty()) : ?>
     <div class="row">
         <div class="col-md-12">
-            <div class="box box-solid">
+            <div class="box box-primary">
                 <div class="box-header with-border">
                     <h3 class="box-title">
                         <?= __('Existing imports') ?>


### PR DESCRIPTION
box-solid styling is a historical legacy, which doesn't really do
much, as it needs the color as well.  If the color is applied, then
the box header becomes too heavy.  Instead, box-solid is now
replaced with box-primary, which adds a tiny top border with the
color.