### PR TITLE
Strict validate (task #5580)

### DIFF
--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -63,6 +63,20 @@ return [
             'initialPreviewConfig' => [
                 'url' => "/api/file-storages/delete/"
             ]
+        ],
+        'ValidateShell' => [
+            'module' => [
+                '_default' => [
+                    'checks' => [
+                        '_checkConfig',
+                        '_checkFields',
+                        '_checkMenus',
+                        '_checkReports',
+                        '_checkMigration',
+                        '_checkViews',
+                    ]
+                ],
+            ]
         ]
     ]
 ];

--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -70,6 +70,7 @@ return [
                     'checks' => [
                         '_checkConfig' => [
                             'display_field_bad_values' => [],
+                            'icon_bad_values' => [],
                         ],
                         '_checkFields' => [],
                         '_checkMenus' => [],

--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -68,12 +68,12 @@ return [
             'module' => [
                 '_default' => [
                     'checks' => [
-                        '_checkConfig',
-                        '_checkFields',
-                        '_checkMenus',
-                        '_checkReports',
-                        '_checkMigration',
-                        '_checkViews',
+                        '_checkConfig' => [],
+                        '_checkFields' => [],
+                        '_checkMenus' => [],
+                        '_checkReports' => [],
+                        '_checkMigration' => [],
+                        '_checkViews' => [],
                     ]
                 ],
             ]

--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -68,7 +68,9 @@ return [
             'module' => [
                 '_default' => [
                     'checks' => [
-                        '_checkConfig' => [],
+                        '_checkConfig' => [
+                            'display_field_bad_values' => [],
+                        ],
                         '_checkFields' => [],
                         '_checkMenus' => [],
                         '_checkReports' => [],

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -80,25 +80,23 @@ class ValidateShell extends Shell
     {
         $result = 0;
 
+        $defaultOptions = Configure::read('CsvMigrations.ValidateShell.module._default');
         foreach ($modules as $module) {
             $errors = [];
             $warnings = [];
-            $checks = [
-                '_checkConfig',
-                '_checkFields',
-                '_checkMenus',
-                '_checkReports',
-                '_checkMigration',
-                '_checkViews',
-            ];
 
             $this->out("Checking module $module", 2);
+
+            $moduleOptions = Configure::read('CsvMigrations.ValidateShell.module.' . $module);
+            $moduleOptions = empty($moduleOptions) ? $defaultOptions : $moduleOptions;
+
+            $checks = $moduleOptions['checks'];
 
             if (!in_array($module, $this->modules)) {
                 $errors[] = "$module is not a known module";
             } else {
                 foreach ($checks as $check) {
-                    $checkResult = $this->$check($module);
+                    $checkResult = $this->$check($module, $moduleOptions);
                     $errors = array_merge($errors, $checkResult['errors']);
                     $warnings = array_merge($warnings, $checkResult['warnings']);
                 }
@@ -324,9 +322,10 @@ class ValidateShell extends Shell
      * Check module config
      *
      * @param string $module Module name
+     * @param array $options Module validation options
      * @return array A list of errors
      */
-    protected function _checkConfig($module)
+    protected function _checkConfig($module, array $options = [])
     {
         $errors = [];
         $warnings = [];
@@ -491,9 +490,10 @@ class ValidateShell extends Shell
      * Check fields config
      *
      * @param string $module Module name
+     * @param array $options Module validation options
      * @return array A list of errors
      */
-    protected function _checkFields($module)
+    protected function _checkFields($module, array $options = [])
     {
         $errors = [];
         $warnings = [];
@@ -524,9 +524,10 @@ class ValidateShell extends Shell
      * Check menus config
      *
      * @param string $module Module name
+     * @param array $options Module validation options
      * @return array A list of errors
      */
-    protected function _checkMenus($module)
+    protected function _checkMenus($module, array $options = [])
     {
         $errors = [];
         $warnings = [];
@@ -557,9 +558,10 @@ class ValidateShell extends Shell
      * Check reports config
      *
      * @param string $module Module name
+     * @param array $options Module validation options
      * @return array A list of errors
      */
-    protected function _checkReports($module)
+    protected function _checkReports($module, array $options = [])
     {
         $errors = [];
         $warnings = [];
@@ -590,9 +592,10 @@ class ValidateShell extends Shell
      * Check module migration
      *
      * @param string $module Module name
+     * @param array $options Module validation options
      * @return array A list of errors
      */
-    protected function _checkMigration($module)
+    protected function _checkMigration($module, array $options = [])
     {
         $errors = [];
         $warnings = [];
@@ -699,9 +702,10 @@ class ValidateShell extends Shell
      * Check module views
      *
      * @param string $module Module name
+     * @param array $options Module validation options
      * @return array A list of errors
      */
-    protected function _checkViews($module)
+    protected function _checkViews($module, array $options = [])
     {
         $errors = [];
         $warnings = [];

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -354,6 +354,13 @@ class ValidateShell extends Shell
                         $errors[] = $module . " config [table] section uses bad value '" . $config['table']['display_field'] . "' in 'display_field' key";
                     }
                 }
+                // 'icon' key is optional, but must contain good values if specified
+                if (!empty($config['table']['icon'])) {
+                    if (!empty($options['icon_bad_values']) && in_array($config['table']['icon'], $options['icon_bad_values'])) {
+                        $errors[] = $module . " config [table] section uses bad value '" . $config['table']['icon'] . "' in 'icon' key";
+                    }
+                }
+
                 // 'typeahead_fields' key is optional, but must contain valid fields if specified
                 if (!empty($config['table']['typeahead_fields'])) {
                     foreach ($config['table']['typeahead_fields'] as $typeaheadField) {

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -95,8 +95,8 @@ class ValidateShell extends Shell
             if (!in_array($module, $this->modules)) {
                 $errors[] = "$module is not a known module";
             } else {
-                foreach ($checks as $check) {
-                    $checkResult = $this->$check($module, $moduleOptions);
+                foreach ($checks as $check => $options) {
+                    $checkResult = $this->$check($module, $options);
                     $errors = array_merge($errors, $checkResult['errors']);
                     $warnings = array_merge($warnings, $checkResult['warnings']);
                 }

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -35,7 +35,7 @@ class ValidateShell extends Shell
     public function getOptionParser()
     {
         $parser = new ConsoleOptionParser('console');
-        $parser->description('Validate CSV and configuration files of all CSV modules');
+        $parser->description('Validate modules configuration');
         $parser->addArgument('modules', [
             'help' => 'Comma-separated list of modules to validate.  All will be checked if omitted.',
         ]);
@@ -58,14 +58,14 @@ class ValidateShell extends Shell
             $modules = [];
         }
 
-        $this->out('Checking CSV files and configurations');
+        $this->out('Checking modules configuration');
         $this->hr();
 
         $path = Configure::read('CsvMigrations.modules.path');
         $this->modules = Utility::findDirs($path);
 
         if (empty($this->modules)) {
-            $this->out('<warning>Did not find any CSV modules</warning>');
+            $this->out('<warning>Did not find any modules</warning>');
             exit();
         }
 
@@ -79,7 +79,7 @@ class ValidateShell extends Shell
     /**
      * Validate a given list of modules
      *
-     * If the list of modules is omitted, then all CSV
+     * If the list of modules is omitted, then all
      * modules will be validated.
      *
      * @param array $modules List of module names to validate
@@ -108,7 +108,7 @@ class ValidateShell extends Shell
             $this->out("Checking module $module", 2);
 
             if (!in_array($module, $this->modules)) {
-                $errors[] = "$module is not a CSV module";
+                $errors[] = "$module is not a known module";
             } else {
                 foreach ($checks as $check) {
                     $checkResult = $this->$check($module);

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -62,7 +62,7 @@ class ValidateShell extends Shell
             exit();
         }
 
-        $modules = empty($modules) ? [] : explode(',', (string)$modules);
+        $modules = empty($modules) ? $this->modules : explode(',', (string)$modules);
         $errorsCount = $this->validateModules($modules);
         if ($errorsCount > 0) {
             $this->abort("Errors found: $errorsCount.  Validation failed!");
@@ -73,19 +73,12 @@ class ValidateShell extends Shell
     /**
      * Validate a given list of modules
      *
-     * If the list of modules is omitted, then all
-     * modules will be validated.
-     *
      * @param array $modules List of module names to validate
      * @return int Count of errors found
      */
-    protected function validateModules(array $modules = [])
+    protected function validateModules(array $modules)
     {
         $result = 0;
-
-        if (empty($modules)) {
-            $modules = $this->modules;
-        }
 
         foreach ($modules as $module) {
             $errors = [];

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -350,6 +350,9 @@ class ValidateShell extends Shell
                     if (!$this->_isValidModuleField($module, $config['table']['display_field'])) {
                         $errors[] = $module . " config [table] section references unknown field '" . $config['table']['display_field'] . "' in 'display_field' key";
                     }
+                    if (!empty($options['display_field_bad_values']) && in_array($config['table']['display_field'], $options['display_field_bad_values'])) {
+                        $errors[] = $module . " config [table] section uses bad value '" . $config['table']['display_field'] . "' in 'display_field' key";
+                    }
                 }
                 // 'typeahead_fields' key is optional, but must contain valid fields if specified
                 if (!empty($config['table']['typeahead_fields'])) {

--- a/src/Shell/ValidateShell.php
+++ b/src/Shell/ValidateShell.php
@@ -51,13 +51,6 @@ class ValidateShell extends Shell
      */
     public function main($modules = null)
     {
-        $modules = (string)$modules;
-        if (!empty($modules)) {
-            $modules = explode(',', $modules);
-        } else {
-            $modules = [];
-        }
-
         $this->out('Checking modules configuration');
         $this->hr();
 
@@ -69,6 +62,7 @@ class ValidateShell extends Shell
             exit();
         }
 
+        $modules = empty($modules) ? [] : explode(',', (string)$modules);
         $errorsCount = $this->validateModules($modules);
         if ($errorsCount > 0) {
             $this->abort("Errors found: $errorsCount.  Validation failed!");


### PR DESCRIPTION
* Removed some obsolete references to CSV from Validate Shell messages.
* Minor code refactoring in Validate Shell.
* Validate Shell now has configuration options.
* Added support for optional strict checks of values in module config:
  * `display_field` not set to human unfriendly value like 'id'
  * `icon` not set to human unfriendly default like 'cube'