### PR TITLE
Fix for index method compatibility warning (task #5716)

### DIFF
--- a/src/Controller/DblistItemsController.php
+++ b/src/Controller/DblistItemsController.php
@@ -26,7 +26,7 @@ class DblistItemsController extends BaseController
      * @param string $id Associated Dblist id
      * @return \Cake\Network\Response|null
      */
-    public function index($id)
+    public function index($id = '')
     {
         $list = $this->DblistItems->Dblists->get($id);
         $query = $this->DblistItems->find('treeEntities', ['listId' => $id]);


### PR DESCRIPTION
Fixes following PHP warning:
```php
Declaration of CsvMigrations\Controller\DblistItemsController::index($id) should be compatible with App\Controller\AppController::index()
```