### PR TITLE
Adding dynamic content loading of dataTables (task #5963)

### DIFF
--- a/src/Template/Element/Associated/tab-content.ctp
+++ b/src/Template/Element/Associated/tab-content.ctp
@@ -77,7 +77,15 @@ $dtOptions = [
     ],
 ];
 
-echo $this->Html->scriptBlock('new DataTablesInit(' . json_encode($dtOptions) . ');', ['block' => 'scriptBottom']);
+echo $this->Html->scriptBlock("
+$('#relatedTabs a.$containerId').on('click', function() {
+    if ( ! $.fn.DataTable.isDataTable('#$tableId') ) {
+        new DataTablesInit(" . json_encode($dtOptions) . ");
+    }
+});
+", [
+    'block' => 'scriptBottom'
+]);
 ?>
 <div class="table-responsive">
     <table id="<?= $tableId ?>" class="table table-hover table-condensed table-vertical-align" width="100%">

--- a/src/Template/Element/Associated/tabs-content.ctp
+++ b/src/Template/Element/Associated/tabs-content.ctp
@@ -31,9 +31,26 @@ use Cake\Utility\Inflector;
                 echo $this->element('CsvMigrations.Embedded/lookup', ['association' => $association]);
             } ?>
             <?= $this->element('CsvMigrations.Associated/tab-content', [
-                'association' => $association, 'table' => $table, 'url' => $this->Url->build($url), 'factory' => $factory
+                'association' => $association, 'table' => $table, 'url' => $this->Url->build($url), 'factory' => $factory, 'tableContainerId' => $containerId
             ]) ?>
         </div>
         <?php $active = ''; ?>
     <?php endforeach; ?>
 </div> <!-- .tab-content -->
+<?php
+echo $this->Html->scriptBlock("
+$('#relatedTabs li').each(function(key, element) {
+    var activeTab = localStorage.getItem('activeTab_relatedTabs');
+    var link = $(this).find('a');
+    if (activeTab !== undefined) {
+        if (activeTab == key) {
+            $(link).click();
+        }
+    } else {
+        if ($(this).hasClass('active')) {
+            $(link).click();
+        }
+    }
+});
+", ['block' => 'scriptBottom']);
+?>

--- a/src/Template/Element/Associated/tabs-list.ctp
+++ b/src/Template/Element/Associated/tabs-list.ctp
@@ -23,7 +23,7 @@ use Cake\Utility\Inflector;
         ?>
         <li role="presentation" class="<?= $active ?>">
             <?= $this->Html->link($label, '#' . $containerId, [
-                'role' => 'tab', 'data-toggle' => 'tab', 'escape' => false
+                'role' => 'tab', 'data-toggle' => 'tab', 'escape' => false, 'class' => $containerId
             ]);?>
         </li>
         <?php $active = ''; ?>


### PR DESCRIPTION
DataTables were loaded asynchronously to all the related tabs once the user is viewing the record.

As a quick fix, we trigger DataTables init function only when specific tab is clicked, or `activeTab` variable loaded from browser's localStorage.