### PR TITLE
Proposing Rich value list field handler (task #6106)

### DIFF
--- a/src/FieldHandlers/Config/ConfigFactory.php
+++ b/src/FieldHandlers/Config/ConfigFactory.php
@@ -11,6 +11,7 @@
  */
 namespace CsvMigrations\FieldHandlers\Config;
 
+use Cake\Utility\Inflector;
 use RuntimeException;
 
 /**
@@ -33,7 +34,8 @@ class ConfigFactory
      */
     public static function getByType($type, $field, $table = null, array $options = [])
     {
-        $configClass = __NAMESPACE__ . '\\' . ucfirst($type) . 'Config';
+        $configClass = __NAMESPACE__ . '\\' . Inflector::camelize($type) . 'Config';
+
         if (!class_exists($configClass)) {
             throw new RuntimeException("Configuration type [$type] is not supported");
         }

--- a/src/FieldHandlers/Config/RichListConfig.php
+++ b/src/FieldHandlers/Config/RichListConfig.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Config;
+
+/**
+ * RichListConfig
+ *
+ * This class provides the predefined configuration
+ * for list field handlers.
+ */
+class RichListConfig extends ListConfig
+{
+    /**
+     * @var array $providers List of provider names and classes
+     */
+    protected $providers = [
+        'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\StringDbFieldType',
+        'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
+        'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\ListFieldToDb',
+        'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\ListSearchOperators',
+        'searchOptions' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOptions\\ListSearchOptions',
+        'selectOptions' => '\\CsvMigrations\\FieldHandlers\\Provider\\SelectOptions\\ListSelectOptions',
+        'renderInput' => '\\CsvMigrations\\FieldHandlers\\Provider\\RenderInput\\RichListRenderer',
+        'renderValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\RenderValue\\RichListRenderer',
+        'renderName' => '\\CsvMigrations\\FieldHandlers\\Provider\\RenderName\\DefaultRenderer',
+    ];
+}

--- a/src/FieldHandlers/FieldHandler.php
+++ b/src/FieldHandlers/FieldHandler.php
@@ -330,7 +330,7 @@ class FieldHandler implements FieldHandlerInterface
 
         $rendererClass = $this->config->getProvider('renderValue');
         if (!empty($options['renderAs'])) {
-            $rendererClass = __NAMESPACE__ . '\\Provider\\RenderValue\\' . ucfirst($options['renderAs']) . 'Renderer';
+            $rendererClass = __NAMESPACE__ . '\\Provider\\RenderValue\\' . Inflector::camelize($options['renderAs']) . 'Renderer';
         }
 
         if (!class_exists($rendererClass)) {

--- a/src/FieldHandlers/Provider/RenderInput/RichListRenderer.php
+++ b/src/FieldHandlers/Provider/RenderInput/RichListRenderer.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\RenderInput;
+
+use CsvMigrations\FieldHandlers\Setting;
+
+/**
+ * ListRenderer
+ *
+ * List renderer provides the functionality
+ * for rendering list inputs.
+ */
+class RichListRenderer extends AbstractRenderer
+{
+    /**
+     * Provide
+     *
+     * @param mixed $data Data to use for provision
+     * @param array $options Options to use for provision
+     * @return mixed
+     */
+    public function provide($data = null, array $options = [])
+    {
+        $field = $this->config->getField();
+        $table = $this->config->getTable();
+
+        $fieldName = $table->aliasField($field);
+
+        $selectOptions = ['' => Setting::EMPTY_OPTION_LABEL()];
+
+        // if select options are not pre-defined
+        if (empty($options['selectOptions'])) {
+            $selectListItems = $this->config->getProvider('selectOptions');
+            $selectListItems = new $selectListItems($this->config);
+            $listName = $options['fieldDefinitions']->getLimit();
+            $listOptions = [];
+            $selectOptions += $selectListItems->provide($listName, $listOptions);
+        } else {
+            $selectOptions += $options['selectOptions'];
+        }
+
+        $params = [
+            'field' => $field,
+            'name' => $fieldName,
+            'type' => 'select',
+            'label' => $options['label'],
+            'required' => $options['fieldDefinitions']->getRequired(),
+            'value' => $data,
+            'options' => $selectOptions,
+            'extraClasses' => (!empty($options['extraClasses']) ? implode(' ', $options['extraClasses']) : ''),
+            'attributes' => empty($options['attributes']) ? [] : $options['attributes'],
+        ];
+
+        $defaultElement = 'CsvMigrations.FieldHandlers/RichListFieldHandler/input';
+        $element = empty($options['element']) ? $defaultElement : $options['element'];
+
+        return $this->renderElement($element, $params);
+    }
+}

--- a/src/FieldHandlers/Provider/RenderValue/RichListRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/RichListRenderer.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\RenderValue;
+
+/**
+ * RichListRenderer
+ *
+ * Render value as list item
+ */
+class RichListRenderer extends ListRenderer
+{
+}

--- a/src/Template/Element/FieldHandlers/RichListFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/RichListFieldHandler/input.ctp
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+$attributes = isset($attributes) ? $attributes : [];
+
+$id = 'select2-' . uniqid();
+
+$attributes += [
+    'id' => $id,
+    'type' => 'select',
+    'label' => false,
+    'options' => $options,
+    'data-type' => 'select2',
+    'data-backend' => "off",
+    'class' => 'select2 form-control ' . $extraClasses,
+    'required' => (bool)$required,
+    'value' => $value,
+    'escape' => true,
+];
+?>
+<div class="form-group <?= $required ? 'required' : '' ?> <?= $this->Form->isFieldError($name) ? 'has-error' : '' ?>">
+    <?= $this->Form->label($name, $label, ['class' => 'control-label']) ?>
+    <div class="input-group">
+        <div class="input-group-addon" title="" data-backend="on">
+            <span class="fa fa-list"></span>
+        </div>
+        <?= $this->Form->input($name, $attributes);
+        ?>
+    </div>
+    <?php echo $this->Form->error($name) ?>
+</div>

--- a/tests/TestCase/FieldHandlers/RichListFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/RichListFieldHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace CsvMigrations\Test\TestCase\FieldHandlers;
+
+use Cake\Core\Configure;
+use CsvMigrations\FieldHandlers\Config\ConfigFactory;
+use CsvMigrations\FieldHandlers\CsvField;
+use CsvMigrations\FieldHandlers\FieldHandler;
+use PHPUnit_Framework_TestCase;
+
+class RichListFieldHandlerTest extends PHPUnit_Framework_TestCase
+{
+    protected $table = 'fields';
+    protected $field = 'field_list';
+    protected $type = 'rich_list';
+
+    protected $fh;
+
+    protected function setUp()
+    {
+        $dir = dirname(__DIR__) . DS . '..' . DS . 'config' . DS . 'Modules' . DS;
+        Configure::write('CsvMigrations.modules.path', $dir);
+
+        $config = ConfigFactory::getByType($this->type, $this->field, $this->table);
+        $this->fh = new FieldHandler($config);
+    }
+
+    public function getRenderedValues()
+    {
+        return [
+            ['', ''],
+            ['cy', '<strong>Cyprus</strong>'],
+            ['usa', '<em>USA</em>'],
+        ];
+    }
+
+    /**
+     * @dataProvider getRenderedValues
+     */
+    public function testRenderValue($value, $expected)
+    {
+        $options['fieldDefinitions'] = new CsvField([
+            'name' => $this->field,
+            'type' => 'rich_list(colors)',
+            'required' => false,
+            'non-searchable' => false,
+            'unique' => false
+        ]);
+
+
+        $result = $this->fh->renderValue($value, $options);
+    }
+}

--- a/tests/config/Modules/Common/lists/colors.json
+++ b/tests/config/Modules/Common/lists/colors.json
@@ -1,0 +1,16 @@
+{
+    "items": [
+        {
+            "value": "cy",
+            "label": "<strong>Cyprus</strong>",
+            "inactive": "",
+            "children": []
+        },
+        {
+            "value": "usa",
+            "label": "<em>USA</em>",
+            "inactive": "",
+            "children": []
+        }
+    ]
+}

--- a/webroot/js/select2.init.js
+++ b/webroot/js/select2.init.js
@@ -69,16 +69,23 @@ var csv_migrations_select2 = csv_migrations_select2 || {};
     Select2.prototype._enable = function (input) {
         var that = this;
         var placeholder = $(input).attr('title');
-        // enable select2
-        $(input).select2({
+        var isAjaxEnabled = $(input).data('backend');
+        var args = {
             theme: 'bootstrap',
             width: '100%',
             placeholder: placeholder,
             allowClear: true,
             minimumInputLength: that.min_length,
-            escapeMarkup: function (text) {
-                return text;
-            },
+            escapeMarkup: function (data) {
+                return data;
+            }
+        };
+
+        if (isAjaxEnabled == undefined || isAjaxEnabled == 'on') {
+            isAjaxEnabled = true;
+        }
+
+        var ajaxSettings = {
             ajax: {
                 url: $(input).data('url'),
                 dataType: 'json',
@@ -135,7 +142,12 @@ var csv_migrations_select2 = csv_migrations_select2 || {};
             templateSelection: function (data) {
                 return data.name || data.text;
             }
-        });
+        };
+        if (isAjaxEnabled == true) {
+            args = Object.assign(args, ajaxSettings);
+        }
+        // enable select2
+        $(input).select2(args);
     };
 
     /**


### PR DESCRIPTION
`RichList FieldHandler` allows embedding HTML values into `option` tags with the use of `select2` JS library.

It's an expansion of ListFieldHandler that has been used for JSON lists. It comes in handy for color-defined dropdown lists, and all sorts of HTML-based values for the select input field.

Example of `colors.json`:

```json
{
    "items": [
        {
          "value": "#F3C300",
          "label": "<div style='width:20px;height:20px;margin:0;float:left;background:#F3C300;'></div>Yellow",
          "inactive": null,
          "children": []
        },
        {
          "value": "#875692",
          "label": "<div style='width:20px;height:20px;float:left;background:#875692;'></div>Purple",
          "inactive": null,
          "children": []
        }
    ]
}
```

Example of `db/migration.json`:

```json

 "color": {
         "name": "color",
         "type": "rich_list(colors)",
         "required": null,
         "non-searchable": null,
         "unique": null
     }

```
