### PR TITLE
Automagic set items loading (task #6323)

### DIFF
--- a/src/Template/Element/Associated/tabs-content.ctp
+++ b/src/Template/Element/Associated/tabs-content.ctp
@@ -39,18 +39,25 @@ use Cake\Utility\Inflector;
 </div> <!-- .tab-content -->
 <?php
 echo $this->Html->scriptBlock("
-$('#relatedTabs li').each(function(key, element) {
-    var activeTab = localStorage.getItem('activeTab_relatedTabs');
-    var link = $(this).find('a');
-    if (activeTab !== undefined) {
+var tabClicked = false;
+var activeTab = localStorage.getItem('activeTab_relatedTabs');
+
+if (activeTab) {
+    $('#relatedTabs li').each(function(key, element) {
+        var link = $(this).find('a');
         if (activeTab == key) {
+            tabClicked = true;
             $(link).click();
         }
+    });
+}
+if (!tabClicked) {
+    var activeTab = $('#relatedTabs li.active');
+    if (activeTab) {
+        $(activeTab).find('a').click();
     } else {
-        if ($(this).hasClass('active')) {
-            $(link).click();
-        }
+        $('#relatedTabs li').first().find('a').click();
     }
-});
+}
 ", ['block' => 'scriptBottom']);
 ?>


### PR DESCRIPTION
`activeTab` localStorage variable is used to keep the name of currently opened tab on the page.
In case this variable is present, we try to load tab's content correlated to `activeTab` (index of the tab).

The plugin didn't check if `activeTab` exceeds the count of currently shown tabs, neither was checking for fallback of `.active`-li class being present.
