### PR TITLE
Display Field with no value returns empty (task #6708)

### DIFF
--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -112,10 +112,6 @@ class FieldHandlerFactory
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
-        if (empty($data)) {
-            $data = 'N/A';
-        }
-
         $handler = self::getByTableField($table, $field, $options, $this->cakeView);
 
         return $handler->renderValue($data, $options);

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -112,6 +112,10 @@ class FieldHandlerFactory
      */
     public function renderValue($table, $field, $data, array $options = [])
     {
+        if (empty($data)) {
+            $data = 'N/A';
+        }
+
         $handler = self::getByTableField($table, $field, $options, $this->cakeView);
 
         return $handler->renderValue($data, $options);

--- a/src/FieldHandlers/Provider/RenderValue/RelatedPlainRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/RelatedPlainRenderer.php
@@ -35,7 +35,7 @@ class RelatedPlainRenderer extends AbstractRenderer
         $result = null;
 
         if (empty($data)) {
-            return $result;
+            return 'N/A';
         }
 
         if ('related' !== $options['fieldDefinitions']->getType()) {

--- a/src/FieldHandlers/Provider/RenderValue/RelatedRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/RelatedRenderer.php
@@ -58,8 +58,13 @@ class RelatedRenderer extends AbstractRenderer
                 $inputs[] = $properties['dispFieldVal'];
             } else {
                 // generate related record(s) html link
+                $title = $properties['dispFieldVal'];
+                if (isset($properties['config']['table']['icon'])) {
+                    $title = '<i class="menu-icon fa fa-' . $properties['config']['table']['icon'] . '"></i>' . $title;
+                }
+
                 $inputs[] = $view->Html->link(
-                    $properties['dispFieldVal'],
+                    $title,
                     $view->Url->build([
                         'prefix' => false,
                         'plugin' => $properties['plugin'],
@@ -67,7 +72,7 @@ class RelatedRenderer extends AbstractRenderer
                         'action' => 'view',
                         $properties['id']
                     ]),
-                    ['class' => 'label label-primary']
+                    ['class' => 'label label-primary', 'escape' => false]
                 );
             }
         }

--- a/src/FieldHandlers/Provider/RenderValue/RelatedRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/RelatedRenderer.php
@@ -47,40 +47,12 @@ class RelatedRenderer extends AbstractRenderer
             );
         }
 
-        $view = $this->config->getView();
-        $inputs = [];
-        foreach ($relatedProperties as $properties) {
-            if (empty($properties)) {
-                continue;
-            }
+        $elementName = 'CsvMigrations.FieldHandlers/RelatedFieldHandler/view';
+        $params = [
+            'relatedProperties' => $relatedProperties,
+            'options' => $options,
+        ];
 
-            if (isset($options['renderAs']) && $options['renderAs'] === 'plain') {
-                $inputs[] = $properties['dispFieldVal'];
-            } else {
-                // generate related record(s) html link
-                $title = $properties['dispFieldVal'];
-                if (isset($properties['config']['table']['icon'])) {
-                    $title = '<i class="menu-icon fa fa-' . $properties['config']['table']['icon'] . '"></i>' . $title;
-                }
-
-                $inputs[] = $view->Html->link(
-                    $title,
-                    $view->Url->build([
-                        'prefix' => false,
-                        'plugin' => $properties['plugin'],
-                        'controller' => $properties['controller'],
-                        'action' => 'view',
-                        $properties['id']
-                    ]),
-                    ['class' => 'label label-primary', 'escape' => false]
-                );
-            }
-        }
-
-        if (!empty($inputs)) {
-            $result .= implode(' ' . $this->_separator . ' ', $inputs);
-        }
-
-        return $result;
+        return $this->renderElement($elementName, $params);
     }
 }

--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -94,12 +94,13 @@ trait RelatedFieldTrait
             // Pass the value through related field handler
             // to properly display the user-friendly label.
             $fhf = new FieldHandlerFactory();
-            $result['dispFieldVal'] = $fhf->renderValue(
+            $dispFieldVal = $fhf->renderValue(
                 $table,
                 $table->displayField(),
                 $result['entity']->{$table->displayField()},
                 ['renderAs' => Setting::RENDER_PLAIN_VALUE_RELATED()]
             );
+            $result['dispFieldVal'] = empty($dispFieldVal) ? 'N/A' : $dispFieldVal;
         } else {
             $result['dispFieldVal'] = null;
         }

--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -164,16 +164,28 @@ trait RelatedFieldTrait
     protected function _getInputHelp($properties)
     {
         $config = (new ModuleConfig(ConfigType::MODULE(), $properties['controller']))->parse();
+        $fields = $config->table->typeahead_fields;
+        $virtualFields = $config->virtualFields;
 
         // if typeahead fields were not defined, use display field
-        if (empty($config->table->typeahead_fields)) {
-            return Inflector::humanize($properties['displayField']);
+        if (empty($fields)) {
+            $fields = [$properties['displayField']];
+        }
+
+        // extract virtual fields if any
+        $typeaheadFields = [];
+        foreach ($fields as $fieldName) {
+            if (isset($virtualFields->{$fieldName})) {
+                $typeaheadFields = array_merge($typeaheadFields, $virtualFields->{$fieldName});
+            } else {
+                $typeaheadFields[] = $fieldName;
+            }
         }
 
         // use typeahead fields
         return implode(', or ', array_map(function ($value) {
             return Inflector::humanize($value);
-        }, $config->table->typeahead_fields));
+        }, $typeaheadFields));
     }
 
     /**

--- a/src/Template/Element/FieldHandlers/RelatedFieldHandler/view.ctp
+++ b/src/Template/Element/FieldHandlers/RelatedFieldHandler/view.ctp
@@ -1,0 +1,29 @@
+<?php
+
+foreach ($relatedProperties as $properties) {
+    if (empty($properties)) {
+        continue;
+    }
+
+    if (isset($options['renderAs']) && $options['renderAs'] === 'plain') {
+        echo $properties['dispFieldVal'];
+    } else {
+        // generate related record(s) html link
+        $title = $properties['dispFieldVal'];
+        if (isset($properties['config']['table']['icon'])) {
+            $title = '<i class="menu-icon fa fa-' . $properties['config']['table']['icon'] . '"></i> ' . $title;
+        }
+
+        echo $this->Html->link(
+            $title,
+            $this->Url->build([
+                'prefix' => false,
+                'plugin' => $properties['plugin'],
+                'controller' => $properties['controller'],
+                'action' => 'view',
+                $properties['id']
+            ]),
+            ['class' => 'label label-primary', 'escape' => false]
+        );
+    }
+}

--- a/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
@@ -60,7 +60,7 @@ class RelatedFieldHandlerTest extends TestCase
         $this->assertContains('data-url="/api/foo/lookup.json"', $result);
 
         // test helper text
-        $this->assertContains('title="Name, or Foobar"', $result);
+        $this->assertContains('title="Foo, or Bar, or Foobar"', $result);
 
         // test icon
         $this->assertContains('<span class="fa fa-user"></span>', $result);


### PR DESCRIPTION
The PR address the issue of empty display names by providing the following changes:

* No empty values are being displayed. Worst case scenario, 'N/A' is being displayed indicating that the display name is empty.
* Provides the infrastructure to specify a virtual field as the display field. When this is done, the select2 title includes all the real fields that compose the virtual field (and not the virtual field since it's not searchable)