### PR TITLE
Record fetching query fixes (task #6717)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -71,7 +71,7 @@ class AppController extends BaseController
     public function view($id = null)
     {
         $entity = $this->{$this->name}->find()
-            ->where([$this->{$this->name}->getPrimaryKey() => $id])
+            ->where([$this->{$this->name}->aliasField($this->{$this->name}->getPrimaryKey()) => $id])
             ->first();
 
         if (empty($entity)) {

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -16,6 +16,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Log\Log;
 use Cake\Utility\Inflector;
+use Cake\Validation\Validation;
 use CsvMigrations\Controller\Traits\ImportTrait;
 use CsvMigrations\Event\EventName;
 use CsvMigrations\Utility\Field;
@@ -74,7 +75,7 @@ class AppController extends BaseController
             ->where([$this->{$this->name}->aliasField($this->{$this->name}->getPrimaryKey()) => $id])
             ->first();
 
-        if (empty($entity)) {
+        if (null === $entity && ! Validation::uuid($id)) {
             $entity = $this->{$this->name}->find()
                 ->applyOptions(['lookup' => true, 'value' => $id])
                 ->firstOrFail();

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -124,7 +124,7 @@ class AppController extends BaseController
             ->where([$this->{$this->name}->getPrimaryKey() => $id])
             ->first();
 
-        if (empty($entity)) {
+        if (null === $entity && ! Validation::uuid($id)) {
             $entity = $this->{$this->name}->find()
                 ->applyOptions(['lookup' => true, 'value' => $id])
                 ->firstOrFail();

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -75,7 +75,7 @@ class AppController extends BaseController
             ->where([$this->{$this->name}->aliasField($this->{$this->name}->getPrimaryKey()) => $id])
             ->first();
 
-        if (null === $entity && ! Validation::uuid($id)) {
+        if (empty($entity) && ! Validation::uuid($id)) {
             $entity = $this->{$this->name}->find()
                 ->applyOptions(['lookup' => true, 'value' => $id])
                 ->firstOrFail();
@@ -124,7 +124,7 @@ class AppController extends BaseController
             ->where([$this->{$this->name}->getPrimaryKey() => $id])
             ->first();
 
-        if (null === $entity && ! Validation::uuid($id)) {
+        if (empty($entity) && ! Validation::uuid($id)) {
             $entity = $this->{$this->name}->find()
                 ->applyOptions(['lookup' => true, 'value' => $id])
                 ->firstOrFail();

--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -139,7 +139,7 @@ trait RelatedFieldTrait
     protected function _getAssociatedRecord(Table $table, $value)
     {
         $options = [
-            'conditions' => [$table->primaryKey() => $value],
+            'conditions' => [$table->aliasField($table->getPrimaryKey()) => $value],
             'limit' => 1
         ];
         // try to fetch with trashed if finder method exists, otherwise fallback to find all


### PR DESCRIPTION
* Fetch by lookup fields only if the query string ID is not a UUID.
* Applying field alias for the primary key to avoid the following PDO exception:
```sql
Error: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous
```
