### PR TITLE
WC command produces extra spaces that breaks line count (task #6913)

### DIFF
--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -202,7 +202,7 @@ class Import
      */
     public static function getRowsCount($path, $withHeader = false)
     {
-        $result = exec("/usr/bin/env wc -l '" . $path . "'", $output, $return);
+        $result = trim(exec("/usr/bin/env wc -l '" . $path . "'", $output, $return));
         if (0 === $return) {
             list($result, ) = explode(' ', $result);
             $result = (int)$result;


### PR DESCRIPTION
`wc` command, when doing a line count of the CSV file, produces extra spaces that might lead to wrong `$result`:

```php
$result = exec("/usr/bin/env wc -l '" . $path . "'", $output, $return); //needs to be trimmed
        if (0 === $return) {
            list($result, ) = explode(' ', $result);
            $result = (int)$result;
            if (0 < $result) {
                $result -= 1;
            }

            return $result;
        }
```