### PR TITLE
Non-CsvFields import values (Task #6913)

### DIFF
--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -397,9 +397,8 @@ class ImportShell extends Shell
         $result = [];
 
         $schema = $table->schema();
-
         foreach ($data as $field => $value) {
-            if (!empty($csvFields)) {
+            if (!empty($csvFields) && in_array($field, array_keys($csvFields))) {
                 switch ($csvFields[$field]->getType()) {
                     case 'related':
                         $data[$field] = $this->_findRelatedRecord($table, $field, $value);
@@ -411,7 +410,10 @@ class ImportShell extends Shell
             } else {
                 if ('uuid' === $schema->columnType($field)) {
                     $data[$field] = $this->_findRelatedRecord($table, $field, $value);
+                } else {
+                    $data[$field] = $value;
                 }
+
             }
         }
 

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -413,7 +413,6 @@ class ImportShell extends Shell
                 } else {
                     $data[$field] = $value;
                 }
-
             }
         }
 


### PR DESCRIPTION
Allow importing non-csv fields to the database (task #6913)

When we import CSV files from `qobo/cakephp-search` we convert
`metric()` fields into a pair of fields amount/value. If these fields
appear in the CSV the system tries to create a CsvField object out of it.

It fails. In that case we fallback to `$schema` and try storing each fields 
(aka _amount, or _value) as a normal db field.