### PR TITLE
Fixing upload of files (task #6939)

### DIFF
--- a/webroot/js/fileinput-load.js
+++ b/webroot/js/fileinput-load.js
@@ -228,6 +228,14 @@ $(document).ready(function () {
             }
         }
 
+        if (hiddenFields.length) {
+            hiddenFields.forEach(function (element) {
+                if ($(element).val() == '') {
+                    $(element).remove();
+                }
+            });
+        }
+
         return added;
     };
 


### PR DESCRIPTION
When the file is auto-uploaded, the form is appended with cloned form element that keeps `file_id`.

The problem takes place if the $_POST reaches `patchEntity()` method where file's array is unfiltered from empty elements. We make sure that the form won't get any empty file ids.