### PR TITLE
Teach Validate shell about module lists (task #5596)

### DIFF
--- a/src/Utility/Validate/Check/MigrationCheck.php
+++ b/src/Utility/Validate/Check/MigrationCheck.php
@@ -97,7 +97,7 @@ class MigrationCheck extends AbstractCheck
                             case 'list':
                             case 'money':
                             case 'metric':
-                                if (!Utility::isValidList($limit)) {
+                                if (!Utility::isValidList($limit, $module)) {
                                     $this->errors[] = $module . " migration uses unknown or empty list '$limit' in '" . $field['name'] . "' field";
                                 }
                                 break;

--- a/src/Utility/Validate/Utility.php
+++ b/src/Utility/Validate/Utility.php
@@ -65,13 +65,13 @@ class Utility
      * invalid.
      *
      * @param string $list List name to check
+     * $param string $module Module name to check the list in
      * @return bool True if valid, false is otherwise
      */
-    public static function isValidList($list)
+    public static function isValidList($list, $module = null)
     {
         $result = false;
 
-        $module = null;
         if (strpos($list, '.') !== false) {
             list($module, $list) = explode('.', $list, 2);
         }


### PR DESCRIPTION
Validate shell wasn't fully aware of the list configurations done
on the module level.  Now it knows.