### PR TITLE
[WIP] DataTable reload on record deletion (task #7074)

### DIFF
--- a/src/Template/Element/Associated/tab-content.ctp
+++ b/src/Template/Element/Associated/tab-content.ctp
@@ -81,6 +81,8 @@ echo $this->Html->scriptBlock("
 $('#relatedTabs a.$containerId').on('click', function() {
     if ( ! $.fn.DataTable.isDataTable('#$tableId') ) {
         new DataTablesInit(" . json_encode($dtOptions) . ");
+    } else {
+        $('#$tableId').DataTable().ajax.reload();
     }
 });
 ", [

--- a/webroot/js/plugin.js
+++ b/webroot/js/plugin.js
@@ -22,7 +22,7 @@ $(document).ready(function () {
                 },
                 success: function (data) {
                     //traverse upwards on the tree to find table instance and reload it
-                    var table = $(hrefObj).closest('.table-datatable').DataTable();
+                    var table = $(hrefObj).closest('.dataTable').DataTable();
                     table.ajax.reload();
 
                 }


### PR DESCRIPTION
Fix for DataTable not reloading when a record is deleted. Additionally, the relevant DataTable will be reloaded whenever the related tab is clicked.