### PR TITLE
Remove default menu icon from bake template (task #5348)

### DIFF
--- a/src/Template/Bake/Module/config/menus.twig
+++ b/src/Template/Bake/Module/config/menus.twig
@@ -3,7 +3,6 @@
         {
             "label": "{{ label }}",
             "url": "{{ url }}",
-            "icon": "cube",
             "order": 40
         }
     ]


### PR DESCRIPTION
Removes default icon as provided by Bake templates. Default icons will be applied on runtime through cakephp-menu plugin and other event listeners.