### PR TITLE
View screens grid adjustments (task #7147)

### DIFF
--- a/src/Template/Element/Field/input.ctp
+++ b/src/Template/Element/Field/input.ctp
@@ -55,5 +55,9 @@ if ('' !== trim($field['name'])) {
             break;
     }
 }
+
+// calculate column width
+$columnWidth = (int)floor(12 / $fieldCount);
+$columnWidth = 6 < $columnWidth ? 6 : $columnWidth; // max-supported input size is half grid
 ?>
-<div class="col-xs-12 col-md-6 field-wrapper"><?= $value ?></div>
+<div class="col-xs-12 col-md-<?= $columnWidth ?> field-wrapper"><?= $value ?></div>

--- a/src/Template/Element/Field/value.ctp
+++ b/src/Template/Element/Field/value.ctp
@@ -19,8 +19,7 @@ $renderOptions = ['entity' => $options['entity'], 'imageSize' => 'small'];
 
 $label = $factory->renderName($tableName, $field['name'], $renderOptions);
 $value = $factory->renderValue($tableName, $field['name'], $options['entity'], $renderOptions);
-// $value = empty($value) ? '&nbsp;' : $value;
-$value = empty($value) ? 'Lorem ipsum' : $value;
+$value = empty($value) ? '&nbsp;' : $value;
 
 // calculate column width
 $columnWidth = (int)floor(12 / $fieldCount);

--- a/src/Template/Element/Field/value.ctp
+++ b/src/Template/Element/Field/value.ctp
@@ -19,6 +19,22 @@ $renderOptions = ['entity' => $options['entity'], 'imageSize' => 'small'];
 
 $label = $factory->renderName($tableName, $field['name'], $renderOptions);
 $value = $factory->renderValue($tableName, $field['name'], $options['entity'], $renderOptions);
+// $value = empty($value) ? '&nbsp;' : $value;
+$value = empty($value) ? 'Lorem ipsum' : $value;
+
+// calculate column width
+$columnWidth = (int)floor(12 / $fieldCount);
+$columnWidth = 6 < $columnWidth ? 6 : $columnWidth; // max-supported input size is half grid
 ?>
-<div class="col-xs-4 col-md-2 text-right"><strong><?= $label ?>:</strong></div>
-<div class="col-xs-8 col-md-4"><?= !empty($value) ? $value : '&nbsp;' ?></div>
+<?php if (2 >= $fieldCountMax) : // horizontal style ?>
+    <div class="col-xs-4 col-md-2 text-right"><strong><?= $label ?>:</strong></div>
+    <div class="col-xs-8 col-md-4"><?= $value ?></div>
+<?php endif ?>
+<?php if (2 < $fieldCountMax) : // default style ?>
+    <div class="col-xs-12 col-md-<?= $columnWidth ?>">
+        <div class="form-group">
+            <label class="control-label"><?= $label ?></label><br />
+            <?= $value ?>
+        </div>
+    </div>
+<?php endif ?>

--- a/src/Template/Element/Form/fields_panel.ctp
+++ b/src/Template/Element/Form/fields_panel.ctp
@@ -12,11 +12,13 @@
 
 ?>
 <?php foreach ($panelFields as $subFields) : ?>
+    <?php $fieldCount = 12 < count($subFields) ? 12 : count($subFields); ?>
 <div class="row">
     <?php foreach ($subFields as $field) : ?>
         <?= $this->element('CsvMigrations.Field/input', [
             'factory' => $factory,
             'field' => $field,
+            'fieldCount' => $fieldCount,
             'options' => $options
         ]) ?>
     <?php endforeach ?>

--- a/src/Template/Element/View/view.ctp
+++ b/src/Template/Element/View/view.ctp
@@ -74,6 +74,16 @@ if (!$this->request->query('embedded')) : ?>
 <section class="content">
 <?php endif; ?>
 <?php
+// row field count with most fields
+$fieldCountMax = 1;
+foreach ($options['fields'] as $panelFields) {
+    foreach ($panelFields as $subFields) {
+        if (count($subFields) > $fieldCountMax) {
+            $fieldCountMax = count($subFields);
+        }
+    }
+}
+
 $embeddedFields = [];
 foreach ($options['fields'] as $panelName => $panelFields) : ?>
     <?php
@@ -94,6 +104,7 @@ foreach ($options['fields'] as $panelName => $panelFields) : ?>
         <?php foreach ($panelFields as $subFields) : ?>
             <div class="row">
             <?php foreach ($subFields as $field) : ?>
+                <?php $fieldCount = 12 < count($subFields) ? 12 : count($subFields); ?>
                 <?php if ('' === trim($field['name'])) : ?>
                     <div class="col-xs-4 col-md-2 text-right">&nbsp;</div>
                     <div class="col-xs-8 col-md-4">&nbsp;</div>
@@ -109,7 +120,11 @@ foreach ($options['fields'] as $panelName => $panelFields) : ?>
                 }
 
                 echo $this->element('CsvMigrations.Field/value', [
-                    'factory' => $factory, 'field' => $field, 'options' => $options
+                    'factory' => $factory,
+                    'field' => $field,
+                    'options' => $options,
+                    'fieldCount' => $fieldCount,
+                    'fieldCountMax' => $fieldCountMax
                 ]);
                 ?>
                 <div class="clearfix visible-xs visible-sm"></div>

--- a/src/Utility/Validate/Check/ViewsCheck.php
+++ b/src/Utility/Validate/Check/ViewsCheck.php
@@ -66,7 +66,7 @@ class ViewsCheck extends AbstractCheck
             }
 
             foreach ($fields as $field) {
-                if (count($field) > 13) {
+                if (count($field) > 13) { // Panel name + 12 fields of the grid maximum
                     $this->errors[] = $module . " module [$view] view has more than 12 columns";
                     continue;
                 }


### PR DESCRIPTION
This PR adjusts the grid layout for add/edit/view screens to support rendering of up to 12 fields per row.

![grid-layout](https://user-images.githubusercontent.com/1926811/45545389-c814b800-b822-11e8-990a-6c7a94eb6b38.png)
_record add view_

![grid-layout-detailed-view](https://user-images.githubusercontent.com/1926811/45545714-cbf50a00-b823-11e8-84f9-e7279fc37d0a.png)
_record detailed view_
