### PR TITLE
Bugfix for many-to-many associations (task #7224)

### DIFF
--- a/src/Model/AssociationsAwareTrait.php
+++ b/src/Model/AssociationsAwareTrait.php
@@ -210,6 +210,13 @@ trait AssociationsAwareTrait
             return;
         }
 
+        // skip for fields associated with Footprint behavior ('related' type fields associated with Users table)
+        if ($this->hasBehavior('Footprint') &&
+            in_array($field->getName(), $this->behaviors()->get('Footprint')->getConfig())
+        ) {
+            return;
+        }
+
         $this->setAssociation(
             'belongsToMany',
             static::generateAssociationName($module, $field->getName()),

--- a/src/Model/Behavior/FootprintBehavior.php
+++ b/src/Model/Behavior/FootprintBehavior.php
@@ -1,0 +1,60 @@
+<?php
+namespace CsvMigrations\Model\Behavior;
+
+use ArrayObject;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\Event;
+use Cake\ORM\Behavior;
+
+class FootprintBehavior extends Behavior
+{
+    /**
+     * Default configuration.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'created_by' => 'created_by',
+        'modified_by' => 'modified_by'
+    ];
+
+    /**
+     * Initialize method.
+     *
+     * @param array $config Behavior configuration
+     * @return void
+     */
+    public function initialize(array $config)
+    {
+        $this->setConfig($config);
+    }
+
+    /**
+     * BeforeSave callback method.
+     *
+     * @param \Cake\Event\Event $event Event object
+     * @param \Cake\Datasource\EntityInterface $entity Entity instance
+     * @param \ArrayObject $options Query options
+     * @return void
+     */
+    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
+    {
+        if (! method_exists($this->getTable(), 'getCurrentUser')) {
+            return;
+        }
+
+        if (! is_callable([$this->getTable(), 'getCurrentUser'])) {
+            return;
+        }
+
+        $user = $this->getTable()->getCurrentUser();
+        if (empty($user['id'])) {
+            return;
+        }
+
+        $entity->set($this->getConfig('modified_by'), $user['id']);
+        if ($entity->isNew()) {
+            $entity->set($this->getConfig('created_by'), $user['id']);
+        }
+    }
+}

--- a/src/Table.php
+++ b/src/Table.php
@@ -81,6 +81,7 @@ class Table extends BaseTable
         parent::initialize($config);
 
         $this->addBehavior('Muffin/Trash.Trash');
+        $this->addBehavior('CsvMigrations.Footprint');
 
         $config = (new ModuleConfig(
             ConfigType::MODULE(),
@@ -115,23 +116,6 @@ class Table extends BaseTable
         }
 
         return $validator;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
-    {
-        $user = $this->getCurrentUser();
-
-        if (empty($user['id'])) {
-            return;
-        }
-
-        $entity->set('modified_by', $user['id']);
-        if ($entity->isNew()) {
-            $entity->set('created_by', $user['id']);
-        }
     }
 
     /**

--- a/tests/Fixture/FooFixture.php
+++ b/tests/Fixture/FooFixture.php
@@ -28,6 +28,8 @@ class FooFixture extends TestFixture
         'balance' => ['type' => 'decimal', 'length' => 8, 'precision' => 4, 'null' => true],
         'created' => ['type' => 'datetime', 'null' => true],
         'modified' => ['type' => 'datetime', 'null' => true],
+        'created_by' => ['type' => 'uuid', 'null' => true],
+        'modified_by' => ['type' => 'uuid', 'null' => true],
         'is_primary' => ['type' => 'boolean', 'null' => true],
         'trashed' => ['type' => 'datetime', 'null' => true],
         '_constraints' => [

--- a/tests/TestCase/Model/Table/FooTableTest.php
+++ b/tests/TestCase/Model/Table/FooTableTest.php
@@ -2,9 +2,12 @@
 namespace CsvMigrations\Test\TestCase\Model\Table;
 
 use Cake\Core\Configure;
+use Cake\Datasource\RepositoryInterface;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;
+use CsvMigrations\Table as CsvMigrationsTable;
 
 /**
  * CsvMigrations\Test\TestCase\Model\Table\FooTable Test Case
@@ -38,6 +41,36 @@ class FooTableTest extends TestCase
         unset($this->table);
 
         parent::tearDown();
+    }
+
+    public function testInitialize()
+    {
+        $this->assertInstanceOf(Table::class, $this->table);
+        $this->assertInstanceOf(RepositoryInterface::class, $this->table);
+        $this->assertInstanceOf(CsvMigrationsTable::class, $this->table);
+
+        $this->assertSame('foo', $this->table->getTable());
+        $this->assertSame('Foo', $this->table->getAlias());
+        $this->assertSame('Foo', $this->table->getRegistryAlias());
+        $this->assertSame('id', $this->table->getPrimaryKey());
+        $this->assertSame('name', $this->table->getDisplayField());
+
+        $this->assertTrue($this->table->hasBehavior('Timestamp'));
+        $this->assertTrue($this->table->hasBehavior('Trash'));
+        $this->assertTrue($this->table->hasBehavior('Footprint'));
+    }
+
+    public function testSaveWithFootprint()
+    {
+        $entity = $this->table->newEntity(['name' => 'John Smith', 'status' => 'new', 'type' => 'bla bla']);
+
+        $expected = 123;
+        $result = $this->table->setCurrentUser(['id' => $expected]);
+
+        $this->table->save($entity);
+
+        $this->assertEquals($expected, $entity->get('created_by'));
+        $this->assertEquals($expected, $entity->get('modified_by'));
     }
 
     public function testSetCurrentUser()
@@ -97,7 +130,9 @@ class FooTableTest extends TestCase
                     'is_primary' => ['name' => 'is_primary', 'type' => 'boolean', 'required' => '', 'non-searchable' => '', 'unique' => false],
                     'start_time' => ['name' => 'start_time', 'type' => 'time', 'required' => '', 'non-searchable' => '', 'unique' => false],
                     'balance' => ['name' => 'balance', 'type' => 'decimal(12.4)', 'required' => '', 'non-searchable' => '', 'unique' => false],
-                    'lead' => ['name' => 'lead', 'type' => 'related(Leads)', 'required' => '', 'non-searchable' => '', 'unique' => false]
+                    'lead' => ['name' => 'lead', 'type' => 'related(Leads)', 'required' => '', 'non-searchable' => '', 'unique' => false],
+                    'created_by' => ['name' => 'created_by', 'type' => 'related(Users)', 'required' => '', 'non-searchable' => '', 'unique' => false],
+                    'modified_by' => ['name' => 'modified_by', 'type' => 'related(Users)', 'required' => '', 'non-searchable' => '', 'unique' => false]
                 ]
             ]
         ];

--- a/tests/config/Modules/Foo/db/migration.json
+++ b/tests/config/Modules/Foo/db/migration.json
@@ -124,5 +124,19 @@
         "required": null,
         "non-searchable": null,
         "unique": null
+    },
+    "created_by": {
+        "name": "created_by",
+        "type": "related(Users)",
+        "required": null,
+        "non-searchable": null,
+        "unique": null
+    },
+    "modified_by": {
+        "name": "modified_by",
+        "type": "related(Users)",
+        "required": null,
+        "non-searchable": null,
+        "unique": null
     }
 }


### PR DESCRIPTION
Moved functionality that sets `created_by` and `modified_by` fields from Table class to a newly created Footprint behavior. Additionally, we now skip setting many-to-many associations with fields related to footprint behavior.