### PR TITLE
Bugfix for many-to-many associations (task #7224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
 [![Latest Unstable Version](https://poser.pugx.org/qobo/cakephp-csv-migrations/v/unstable)](https://packagist.org/packages/qobo/cakephp-csv-migrations)
 [![License](https://poser.pugx.org/qobo/cakephp-csv-migrations/license)](https://packagist.org/packages/qobo/cakephp-csv-migrations)
 [![codecov](https://codecov.io/gh/QoboLtd/cakephp-csv-migrations/branch/master/graph/badge.svg)](https://codecov.io/gh/QoboLtd/cakephp-csv-migrations)
+[![BCH compliance](https://bettercodehub.com/edge/badge/QoboLtd/cakephp-csv-migrations?branch=master)](https://bettercodehub.com/)
 
 ## About
 
 CakePHP 3+ plugin for easy creation of application modules, based on a
 variety of the configuration files (CSV/INI/JSON).
 
-Developed by [Qobo](https://www.qobo.biz), used in [Qobrix](https://qobrix.com).
+This plugin is developed by [Qobo](https://www.qobo.biz) for [Qobrix](https://qobrix.com).  It can be used as standalone CakePHP plugin, or as part of the [project-template-cakephp](https://github.com/QoboLtd/project-template-cakephp) installation.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "eluceo/ical": "^0.11.0",
         "qobo/cakephp-translations": "^8.0",
-        "qobo/cakephp-utils": "^7.0",
+        "qobo/cakephp-utils": "^8.0",
         "symfony/expression-language": "^3.1"
     },
     "require-dev": {

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -41,6 +41,7 @@ class AppController extends BaseController
         $this->fileUpload = new FileUpload($this->{$this->name});
 
         $this->loadComponent('CsvMigrations.CsvView');
+        $this->loadComponent('Qobo/Utils.Footprint');
     }
 
     /**

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -24,6 +24,7 @@ use CsvMigrations\Utility\Field;
 use CsvMigrations\Utility\FileUpload;
 use Exception;
 use Psr\Http\Message\ResponseInterface;
+use Qobo\Utils\Utility\User;
 
 class AppController extends BaseController
 {
@@ -41,7 +42,11 @@ class AppController extends BaseController
         $this->fileUpload = new FileUpload($this->{$this->name});
 
         $this->loadComponent('CsvMigrations.CsvView');
-        $this->loadComponent('Qobo/Utils.Footprint');
+
+        // set current user
+        if (property_exists($this, 'Auth')) {
+            User::setCurrentUser($this->Auth->user());
+        }
     }
 
     /**
@@ -57,10 +62,6 @@ class AppController extends BaseController
         $result = parent::beforeFilter($event);
         if ($result instanceof ResponseInterface) {
             return $result;
-        }
-
-        if ($this->Auth->user() && method_exists($this->{$this->name}, 'setCurrentUser')) {
-            $this->{$this->name}->setCurrentUser($this->Auth->user());
         }
     }
 

--- a/src/Model/AssociationsAwareTrait.php
+++ b/src/Model/AssociationsAwareTrait.php
@@ -210,6 +210,13 @@ trait AssociationsAwareTrait
             return;
         }
 
+        // skip for fields associated with Footprint behavior ('related' type fields associated with Users table)
+        if ($this->hasBehavior('Footprint') &&
+            in_array($field->getName(), $this->behaviors()->get('Footprint')->getConfig())
+        ) {
+            return;
+        }
+
         $this->setAssociation(
             'belongsToMany',
             static::generateAssociationName($module, $field->getName()),

--- a/src/Table.php
+++ b/src/Table.php
@@ -28,6 +28,7 @@ use CsvMigrations\MigrationTrait;
 use CsvMigrations\Model\AssociationsAwareTrait;
 use Qobo\Utils\ModuleConfig\ConfigType;
 use Qobo\Utils\ModuleConfig\ModuleConfig;
+use Qobo\Utils\Utility\User;
 
 /**
  * CsvMigrations Table
@@ -101,7 +102,7 @@ class Table extends BaseTable
         EventManager::instance()->dispatch(new Event(
             (string)EventName::MODEL_AFTER_SAVE(),
             $this,
-            ['entity' => $entity, 'options' => ['current_user' => $this->getCurrentUser()]]
+            ['entity' => $entity, 'options' => ['current_user' => User::getCurrentUser()]]
         ));
     }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -81,6 +81,7 @@ class Table extends BaseTable
         parent::initialize($config);
 
         $this->addBehavior('Muffin/Trash.Trash');
+        $this->addBehavior('Qobo/Utils.Footprint');
 
         $config = (new ModuleConfig(
             ConfigType::MODULE(),
@@ -115,23 +116,6 @@ class Table extends BaseTable
         }
 
         return $validator;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
-    {
-        $user = $this->getCurrentUser();
-
-        if (empty($user['id'])) {
-            return;
-        }
-
-        $entity->set('modified_by', $user['id']);
-        if ($entity->isNew()) {
-            $entity->set('created_by', $user['id']);
-        }
     }
 
     /**

--- a/src/Table.php
+++ b/src/Table.php
@@ -41,36 +41,6 @@ class Table extends BaseTable
     use MigrationTrait;
 
     /**
-     * Current user from session
-     *
-     * @var array
-     */
-    protected $_currentUser;
-
-    /**
-     * setCurrentUser
-     *
-     * @param array $user from Cake\Controller\Component\AuthComponent
-     * @return array $_currentUser
-     */
-    public function setCurrentUser($user)
-    {
-        $this->_currentUser = $user;
-
-        return $this->_currentUser;
-    }
-
-    /**
-     * getCurrentUser
-     *
-     * @return array $_currentUser property
-     */
-    public function getCurrentUser()
-    {
-        return $this->_currentUser;
-    }
-
-    /**
      * Initialize
      *
      * @param array $config The configuration for the Table.

--- a/src/Utility/ICal/IcEmail.php
+++ b/src/Utility/ICal/IcEmail.php
@@ -19,6 +19,7 @@ use CsvMigrations\FieldHandlers\FieldHandlerFactory;
 use CsvMigrations\Table as Table;
 use Exception;
 use InvalidArgumentException;
+use Qobo\Utils\Utility\User;
 
 /**
  * Email class
@@ -259,7 +260,7 @@ class IcEmail
             'email',
         ];
 
-        $currentUser = $this->table->getCurrentUser();
+        $currentUser = User::getCurrentUser();
         if (empty($currentUser) || !is_array($currentUser)) {
             return $result;
         }

--- a/tests/Fixture/FooFixture.php
+++ b/tests/Fixture/FooFixture.php
@@ -28,6 +28,8 @@ class FooFixture extends TestFixture
         'balance' => ['type' => 'decimal', 'length' => 8, 'precision' => 4, 'null' => true],
         'created' => ['type' => 'datetime', 'null' => true],
         'modified' => ['type' => 'datetime', 'null' => true],
+        'created_by' => ['type' => 'uuid', 'null' => true],
+        'modified_by' => ['type' => 'uuid', 'null' => true],
         'is_primary' => ['type' => 'boolean', 'null' => true],
         'trashed' => ['type' => 'datetime', 'null' => true],
         '_constraints' => [

--- a/tests/TestCase/Model/Table/FooTableTest.php
+++ b/tests/TestCase/Model/Table/FooTableTest.php
@@ -2,9 +2,12 @@
 namespace CsvMigrations\Test\TestCase\Model\Table;
 
 use Cake\Core\Configure;
+use Cake\Datasource\RepositoryInterface;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;
+use CsvMigrations\Table as CsvMigrationsTable;
 
 /**
  * CsvMigrations\Test\TestCase\Model\Table\FooTable Test Case
@@ -38,6 +41,36 @@ class FooTableTest extends TestCase
         unset($this->table);
 
         parent::tearDown();
+    }
+
+    public function testInitialize()
+    {
+        $this->assertInstanceOf(Table::class, $this->table);
+        $this->assertInstanceOf(RepositoryInterface::class, $this->table);
+        $this->assertInstanceOf(CsvMigrationsTable::class, $this->table);
+
+        $this->assertSame('foo', $this->table->getTable());
+        $this->assertSame('Foo', $this->table->getAlias());
+        $this->assertSame('Foo', $this->table->getRegistryAlias());
+        $this->assertSame('id', $this->table->getPrimaryKey());
+        $this->assertSame('name', $this->table->getDisplayField());
+
+        $this->assertTrue($this->table->hasBehavior('Timestamp'));
+        $this->assertTrue($this->table->hasBehavior('Trash'));
+        $this->assertTrue($this->table->hasBehavior('Footprint'));
+    }
+
+    public function testSaveWithFootprint()
+    {
+        $entity = $this->table->newEntity(['name' => 'John Smith', 'status' => 'new', 'type' => 'bla bla']);
+
+        $expected = 123;
+        $result = $this->table->setCurrentUser(['id' => $expected]);
+
+        $this->table->save($entity);
+
+        $this->assertEquals($expected, $entity->get('created_by'));
+        $this->assertEquals($expected, $entity->get('modified_by'));
     }
 
     public function testSetCurrentUser()
@@ -97,7 +130,9 @@ class FooTableTest extends TestCase
                     'is_primary' => ['name' => 'is_primary', 'type' => 'boolean', 'required' => '', 'non-searchable' => '', 'unique' => false],
                     'start_time' => ['name' => 'start_time', 'type' => 'time', 'required' => '', 'non-searchable' => '', 'unique' => false],
                     'balance' => ['name' => 'balance', 'type' => 'decimal(12.4)', 'required' => '', 'non-searchable' => '', 'unique' => false],
-                    'lead' => ['name' => 'lead', 'type' => 'related(Leads)', 'required' => '', 'non-searchable' => '', 'unique' => false]
+                    'lead' => ['name' => 'lead', 'type' => 'related(Leads)', 'required' => '', 'non-searchable' => '', 'unique' => false],
+                    'created_by' => ['name' => 'created_by', 'type' => 'related(Users)', 'required' => '', 'non-searchable' => '', 'unique' => false],
+                    'modified_by' => ['name' => 'modified_by', 'type' => 'related(Users)', 'required' => '', 'non-searchable' => '', 'unique' => false]
                 ]
             ]
         ];

--- a/tests/TestCase/Model/Table/FooTableTest.php
+++ b/tests/TestCase/Model/Table/FooTableTest.php
@@ -8,6 +8,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;
 use CsvMigrations\Table as CsvMigrationsTable;
+use Qobo\Utils\Utility\User;
 
 /**
  * CsvMigrations\Test\TestCase\Model\Table\FooTable Test Case
@@ -65,22 +66,12 @@ class FooTableTest extends TestCase
         $entity = $this->table->newEntity(['name' => 'John Smith', 'status' => 'new', 'type' => 'bla bla']);
 
         $expected = 123;
-        $result = $this->table->setCurrentUser(['id' => $expected]);
+        User::setCurrentUser(['id' => $expected]);
 
         $this->table->save($entity);
 
         $this->assertEquals($expected, $entity->get('created_by'));
         $this->assertEquals($expected, $entity->get('modified_by'));
-    }
-
-    public function testSetCurrentUser()
-    {
-        $user = ['id' => 123, 'username' => 'some_foo_user'];
-        $result = $this->table->setCurrentUser($user);
-        $this->assertEquals($user, $result, "setCurrentUser did not return the correct user");
-
-        $result = $this->table->getCurrentUser();
-        $this->assertEquals($user, $result, "getCurrentUser did not return the correct user");
     }
 
     public function testGetParentRedirectUrl()

--- a/tests/config/Modules/Foo/db/migration.json
+++ b/tests/config/Modules/Foo/db/migration.json
@@ -124,5 +124,19 @@
         "required": null,
         "non-searchable": null,
         "unique": null
+    },
+    "created_by": {
+        "name": "created_by",
+        "type": "related(Users)",
+        "required": null,
+        "non-searchable": null,
+        "unique": null
+    },
+    "modified_by": {
+        "name": "modified_by",
+        "type": "related(Users)",
+        "required": null,
+        "non-searchable": null,
+        "unique": null
     }
 }


### PR DESCRIPTION
Moved functionality that sets created_by and modified_by fields from Table class to Footprint behavior in [Qobo/Utils](https://github.com/QoboLtd/cakephp-utils) plugin (this PR requires merging and releasing of [this](https://github.com/QoboLtd/cakephp-utils/pull/137) work).
Additionally, we now skip setting many-to-many associations with fields related to footprint behavior.