### PR TITLE
Bugfix for audit stash and footprint fields (task #7277)

### DIFF
--- a/config/Migrations/20180920143232_AddCreatedByToImports.php
+++ b/config/Migrations/20180920143232_AddCreatedByToImports.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddCreatedByToImports extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('imports');
+        $table->addColumn('created_by', 'uuid', [
+            'default' => null,
+            'null' => true,
+        ]);
+        $table->update();
+    }
+}

--- a/config/Migrations/20180920143307_AddModifiedByToImports.php
+++ b/config/Migrations/20180920143307_AddModifiedByToImports.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddModifiedByToImports extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('imports');
+        $table->addColumn('modified_by', 'uuid', [
+            'default' => null,
+            'null' => true,
+        ]);
+        $table->update();
+    }
+}

--- a/src/Model/Table/ImportsTable.php
+++ b/src/Model/Table/ImportsTable.php
@@ -70,6 +70,7 @@ class ImportsTable extends Table
 
         $this->addBehavior('Muffin/Trash.Trash');
         $this->addBehavior('Timestamp');
+        $this->addBehavior('Qobo/Utils.Footprint');
 
         $this->hasMany('ImportResults', [
             'foreignKey' => 'import_id',

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -29,6 +29,7 @@ use Exception;
 use League\Csv\Reader;
 use League\Csv\Writer;
 use Qobo\Utils\Utility\Lock\FileLock;
+use Qobo\Utils\Utility\User;
 
 class ImportShell extends Shell
 {
@@ -78,6 +79,9 @@ class ImportShell extends Shell
         }
 
         foreach ($query->all() as $import) {
+            // set current user to the one who uploaded the import (for footprint behavior)
+            User::setCurrentUser(['id' => $import->get('created_by')]);
+
             $path = ImportUtility::getProcessedFile($import);
             $filename = ImportUtility::getProcessedFile($import, false);
 

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -82,6 +82,10 @@ class ImportShell extends Shell
         }
 
         foreach ($query->all() as $import) {
+            // detach previous iteration listener
+            if (isset($listener)) {
+                EventManager::instance()->off($listener);
+            }
             // set current user to the one who uploaded the import (for footprint behavior)
             User::setCurrentUser(['id' => $import->get('created_by')]);
             // for audit-stash functionality
@@ -101,9 +105,6 @@ class ImportShell extends Shell
                 $this->warn(sprintf('Skipping, no mapping found for "%s"', $filename));
                 $this->out($this->nl(1));
 
-                // detach listener
-                EventManager::instance()->off($listener);
-
                 continue;
             }
 
@@ -119,9 +120,6 @@ class ImportShell extends Shell
                 $this->_existingImport($table, $import, $count);
             }
             $this->out($this->nl(1));
-
-            // detach listener
-            EventManager::instance()->off($listener);
         }
 
         $this->success('Import completed');

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -91,14 +91,15 @@ class ImportShell extends Shell
             $path = ImportUtility::getProcessedFile($import);
             $filename = ImportUtility::getProcessedFile($import, false);
 
-            $this->out('Importing from file: "' . $filename . '"');
+            $this->info(sprintf('Importing file "%s":', $filename));
+            $this->hr();
 
             // process import file
             $this->processImportFile($import);
 
             if (empty($import->get('options'))) {
-                $this->warn('Skipping, no mapping found for file:' . $filename);
-                $this->hr();
+                $this->warn(sprintf('Skipping, no mapping found for "%s"', $filename));
+                $this->out($this->nl(1));
 
                 // detach listener
                 EventManager::instance()->off($listener);
@@ -117,13 +118,13 @@ class ImportShell extends Shell
             if ($table::STATUS_IN_PROGRESS === $import->get('status')) {
                 $this->_existingImport($table, $import, $count);
             }
-            $this->hr();
+            $this->out($this->nl(1));
 
             // detach listener
             EventManager::instance()->off($listener);
         }
 
-        $this->success('Import Completed');
+        $this->success('Import completed');
 
         // unlock file
         $lock->unlock();
@@ -137,7 +138,7 @@ class ImportShell extends Shell
      */
     protected function processImportFile(Import $import)
     {
-        $this->info('Processing import file ..');
+        $this->out('Processing import file ..');
 
         $path = ImportUtility::getProcessedFile($import);
         if (file_exists($path)) {
@@ -241,7 +242,7 @@ class ImportShell extends Shell
         // generate import results records
         $this->createImportResults($import, $count);
 
-        $this->info('Importing records ..');
+        $this->out('Importing records ..');
         $progress = $this->helper('Progress');
         $progress->init();
 
@@ -276,7 +277,7 @@ class ImportShell extends Shell
      */
     protected function createImportResults(Import $import, $count)
     {
-        $this->info('Preparing records ..');
+        $this->out('Preparing records ..');
 
         $progress = $this->helper('Progress');
         $progress->init();


### PR DESCRIPTION
This PR fixes the issue with the current user **not** being stored in the imported record's `created_by` and `modified` fields and in the `audit-stash` log records.