### PR TITLE
Aggregator Configuration class (task #6030)

### DIFF
--- a/src/Aggregator/Configuration.php
+++ b/src/Aggregator/Configuration.php
@@ -1,0 +1,113 @@
+<?php
+namespace CsvMigrations\Aggregator;
+
+use Cake\ORM\TableRegistry;
+use InvalidArgumentException;
+
+/**
+ * This class is used as a storage object for aggregator configuration.
+ */
+final class Configuration
+{
+    /**
+     * Aggregation table.
+     *
+     * @var Cake\Datasource\RepositoryInterface
+     */
+    private $table;
+
+    /**
+     * Aggregation field.
+     *
+     * @var string
+     */
+    private $field;
+
+    /**
+     * Join table instance. Optional as it is used only in limited mode.
+     *
+     * @var Cake\Datasource\RepositoryInterface
+     */
+    private $joinTable = null;
+
+    /**
+     * Field used for displaying purposes,
+     *
+     * @var string
+     */
+    private $displayField;
+
+    /**
+     * Constructor method.
+     *
+     * Mostly used for properties assignment.
+     *
+     * @param string $tableName Aggregation table name
+     * @param string $field Aggregate field name
+     * @param string $displayField Display field name
+     * @param string $joinTable Join Table name
+     * @return void
+     */
+    public function __construct($tableName, $field, $displayField = '', $joinTable = '')
+    {
+        // basic string validation, this can be removed on PHP 7 with string typehinting.
+        foreach (func_get_args() as $key => $argument) {
+            if (! is_string($argument)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Argument %d passed to %s() must be of the type string, %s given.',
+                    $key + 1,
+                    __METHOD__,
+                    gettype($argument)
+                ));
+            }
+        }
+
+        $this->table = TableRegistry::get($tableName);
+        if ('' !== trim($joinTable)) {
+            $this->joinTable = TableRegistry::get($joinTable);
+        }
+
+        $this->field = $field;
+        $this->displayField = $displayField ? $displayField : $field;
+    }
+
+    /**
+     * Aggregate table getter.
+     *
+     * @return \Cake\Datasource\RepositoryInterface
+     */
+    public function getTable()
+    {
+        return $this->table;
+    }
+
+    /**
+     * Aggregate field getter.
+     *
+     * @return string
+     */
+    public function getField()
+    {
+        return $this->field;
+    }
+
+    /**
+     * Join table getter.
+     *
+     * @return \Cake\Datasource\RepositoryInterface
+     */
+    public function getJoinTable()
+    {
+        return $this->joinTable;
+    }
+
+    /**
+     * Display field getter.
+     *
+     * @return string
+     */
+    public function getDisplayField()
+    {
+        return $this->displayField;
+    }
+}

--- a/tests/TestCase/Aggregator/ConfigurationTest.php
+++ b/tests/TestCase/Aggregator/ConfigurationTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace CsvMigrations\Test\TestCase\Aggregator;
+
+use Cake\Datasource\RepositoryInterface;
+use Cake\TestSuite\TestCase;
+use CsvMigrations\Aggregator\Configuration;
+use InvalidArgumentException;
+
+class ConfigurationTest extends TestCase
+{
+    public function testConstructorWithInvalidConfig()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        // invalid first parameter, string expected
+        new Configuration(['tableName'], 'field');
+    }
+
+    public function testGetTable()
+    {
+        $config = new Configuration('tableName', 'field');
+
+        $this->assertInstanceOf(RepositoryInterface::class, $config->getTable());
+    }
+
+    public function testGetField()
+    {
+        $config = new Configuration('tableName', 'field');
+
+        $this->assertEquals('field', $config->getField());
+    }
+
+    public function testGetDisplayField()
+    {
+        $config = new Configuration('tableName', 'field', 'displayField');
+
+        $this->assertEquals('displayField', $config->getDisplayField());
+    }
+
+    public function testGetJoinTable()
+    {
+        $config = new Configuration('tableName', 'field', 'displayField', 'joinTable');
+
+        $this->assertInstanceOf(RepositoryInterface::class, $config->getJoinTable());
+    }
+}


### PR DESCRIPTION
This class is used as a storage object for all aggregator related configuration. Its constructor accepts the following arguments:
- Aggregated table name.
- Aggregated field name.
- Display field name, this is optional and if not provided the aggregated field will be used.
- Join table name, this is optional and should be used only if aggregation will be limited to an entity's associated data.
- Entity instance, this is required only if the join table argument is set and it should include an entity from that table.

### Validation
The `$entity` argument is enforced if join table is provided. Additionally, is required to match the join table's entity class.

### Usage
Configuration for aggregating on "created" column of Articles table:
```php
use CsvMigrations\Aggregator\Configuration;

$configuration = new Configuration('Articles', 'created');
```
Configuration for aggregating on `created` column of `Articles` table, limiting the dataset to the provided `author's` associated articles, and using `title` as display field:
```php
use Cake\ORM\TableRegistry;
use CsvMigrations\Aggregator\Configuration;

$author = TableRegistry::get('Authors')->find()->first();
$configuration = new Configuration('Articles', 'created', 'title', 'Authors', $author);
```