### PR TITLE
Fix for broken select2 search in bootstrap modals (task #7445)

### DIFF
--- a/webroot/js/select2.init.js
+++ b/webroot/js/select2.init.js
@@ -136,6 +136,10 @@ var csv_migrations_select2 = csv_migrations_select2 || {};
                 return data.name || data.text;
             }
         });
+
+        // fix for select2 search not working within bootstrap modals
+        // @link https://github.com/select2/select2/issues/1436#issuecomment-21028474
+        $.fn.modal.Constructor.prototype.enforceFocus = function () {};
     };
 
     /**


### PR DESCRIPTION
This is a port of the [fix](https://github.com/QoboLtd/cakephp-utils/pull/61) already applied in `qobo/cakephp-utils` plugin.