### PR TITLE
Add support for HTML fields (task #2668)

### DIFF
--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -51,6 +51,18 @@ return [
             'id' => '[data-type="select2"]',
             'limit' => 10
         ],
+        // TinyMCE plugin configuration
+        'TinyMCE' => [
+            'selector' => 'textarea.tinymce',
+            'relative_urls' => false,
+            'plugins' => ['link'],
+            'menubar' => false,
+            'toolbar' => 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent link',
+            'browser_spellcheck' => true,
+            'file_browser_callback_types' => '',
+            'theme' => 'modern',
+            'height' => 300
+        ],
         // bootstrap-fileinput configuration
         // link: https://github.com/kartik-v/bootstrap-fileinput
         'BootstrapFileInput' => [

--- a/src/FieldHandlers/Config/HtmlConfig.php
+++ b/src/FieldHandlers/Config/HtmlConfig.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Config;
+
+/**
+ * TextConfig
+ *
+ * This class provides the predefined configuration
+ * for text field handlers.
+ */
+class HtmlConfig extends FixedConfig
+{
+    /**
+     * @var array $providers List of provider names and classes
+     */
+    protected $providers = [
+        'combinedFields' => '\\CsvMigrations\\FieldHandlers\\Provider\\CombinedFields\\NullCombinedFields',
+        'dbFieldType' => '\\CsvMigrations\\FieldHandlers\\Provider\\DbFieldType\\TextDbFieldType',
+        'fieldValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldValue\\MixedFieldValue',
+        'fieldToDb' => '\\CsvMigrations\\FieldHandlers\\Provider\\FieldToDb\\TextFieldToDb',
+        'searchOperators' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOperators\\StringSearchOperators',
+        'searchOptions' => '\\CsvMigrations\\FieldHandlers\\Provider\\SearchOptions\\StringSearchOptions',
+        'selectOptions' => '\\CsvMigrations\\FieldHandlers\\Provider\\SelectOptions\\NullSelectOptions',
+        'renderInput' => '\\CsvMigrations\\FieldHandlers\\Provider\\RenderInput\\HtmlRenderer',
+        'renderValue' => '\\CsvMigrations\\FieldHandlers\\Provider\\RenderValue\\HtmlRenderer',
+        'renderName' => '\\CsvMigrations\\FieldHandlers\\Provider\\RenderName\\DefaultRenderer',
+        'validationRules' => '\\CsvMigrations\\FieldHandlers\\Provider\\ValidationRules\\TextValidationRules',
+    ];
+}

--- a/src/FieldHandlers/Provider/RenderInput/HtmlRenderer.php
+++ b/src/FieldHandlers/Provider/RenderInput/HtmlRenderer.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\RenderInput;
+
+/**
+ * TextRenderer
+ *
+ * Text renderer provides the functionality
+ * for rendering text inputs.
+ */
+class HtmlRenderer extends AbstractRenderer
+{
+    /**
+     * Provide
+     *
+     * @param mixed $data Data to use for provision
+     * @param array $options Options to use for provision
+     * @return mixed
+     */
+    public function provide($data = null, array $options = [])
+    {
+        $field = $this->config->getField();
+        /** @var \Cake\Datasource\RepositoryInterface&\Cake\ORM\Table */
+        $table = $this->config->getTable();
+
+        $fieldName = $table->aliasField($field);
+
+        $params = [
+            'field' => $field,
+            'name' => $fieldName,
+            'type' => 'textarea',
+            'label' => $options['label'],
+            'required' => $options['fieldDefinitions']->getRequired(),
+            'value' => $data,
+            'extraClasses' => (!empty($options['extraClasses']) ? implode(' ', $options['extraClasses']) : ''),
+            'attributes' => empty($options['attributes']) ? [] : $options['attributes'],
+            'placeholder' => (!empty($options['placeholder']) ? $options['placeholder'] : ''),
+        ];
+
+        $defaultElement = 'CsvMigrations.FieldHandlers/HtmlFieldHandler/input';
+        $element = empty($options['element']) ? $defaultElement : $options['element'];
+
+        return $this->renderElement($element, $params);
+    }
+}

--- a/src/FieldHandlers/Provider/RenderValue/HtmlRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/HtmlRenderer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CsvMigrations\FieldHandlers\Provider\RenderValue;
+
+use CsvMigrations\FieldHandlers\Provider\AbstractProvider;
+
+class HtmlRenderer extends AbstractProvider
+{
+    /**
+     * Provide
+     *
+     * @param mixed $data Data to use for provision
+     * @param mixed[] $options Options to use for provision
+     * @return mixed
+     */
+    public function provide($data = null, array $options = [])
+    {
+        // TODO: need to handle this better, type-casting to string will produce errors
+        return (string)$data;
+    }
+}

--- a/src/Template/Element/FieldHandlers/HtmlFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/HtmlFieldHandler/input.ctp
@@ -23,39 +23,3 @@ $attributes += [
 
 echo $this->Form->control($name, $attributes);
 
-use Cake\Core\Configure;
-
-// load tinyMCE editor and elFinder file manager
-echo $this->Html->script('Qobo/Utils./plugins/tinymce/tinymce.min', ['block' => 'scriptBottom']);
-
-// initialize tinyMCE
-echo $this->Html->scriptBlock(
-    'var tinymce_init_config = ' . json_encode(Configure::read('TinyMCE')) . ';',
-    ['block' => 'scriptBottom']
-);
-
-// @todo move this into a js file so we can avoid loading it more than once
-$this->Html->scriptStart(['block' => 'scriptBottom']) ?>
-(function ($) {
-    /**
-     * TinyMCE init
-     */
-    $(document).ready(function () {
-        var config = {};
-        if ('undefined' !== typeof tinymce_init_config) {
-            config = tinymce_init_config;
-        }
-
-        tinyMCE.init(config);
-    });
-
-    // fix issue with link/image pop-up fields not working when tinymce is loaded within bootstrap modal
-    // @link https://github.com/tinymce/tinymce/issues/782#issuecomment-151998981
-    $(document).on('focusin', function (e) {
-        if ($(event.target).closest('.mce-window').length) {
-            e.stopImmediatePropagation();
-        }
-    });
-})(jQuery);
-<?= $this->Html->scriptEnd() ?>
-

--- a/src/Template/Element/FieldHandlers/HtmlFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/HtmlFieldHandler/input.ctp
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+$attributes = isset($attributes) ? $attributes : [];
+
+$attributes += [
+    'type' => $type,
+    'class' => 'tinymce' . ( (isset($extraClasses) && !empty($extraClasses)) ? ' ' . $extraClasses : null ),
+    'label' => $label,
+    'required' => (bool)$required,
+    'value' => $value,
+    'placeholder' => $placeholder,
+];
+
+echo $this->Form->control($name, $attributes);
+
+use Cake\Core\Configure;
+
+// load tinyMCE editor and elFinder file manager
+echo $this->Html->script('Qobo/Utils./plugins/tinymce/tinymce.min', ['block' => 'scriptBottom']);
+
+// initialize tinyMCE
+echo $this->Html->scriptBlock(
+    'var tinymce_init_config = ' . json_encode(Configure::read('TinyMCE')) . ';',
+    ['block' => 'scriptBottom']
+);
+
+// @todo move this into a js file so we can avoid loading it more than once
+$this->Html->scriptStart(['block' => 'scriptBottom']) ?>
+(function ($) {
+    /**
+     * TinyMCE init
+     */
+    $(document).ready(function () {
+        var config = {};
+        if ('undefined' !== typeof tinymce_init_config) {
+            config = tinymce_init_config;
+        }
+
+        tinyMCE.init(config);
+    });
+
+    // fix issue with link/image pop-up fields not working when tinymce is loaded within bootstrap modal
+    // @link https://github.com/tinymce/tinymce/issues/782#issuecomment-151998981
+    $(document).on('focusin', function (e) {
+        if ($(event.target).closest('.mce-window').length) {
+            e.stopImmediatePropagation();
+        }
+    });
+})(jQuery);
+<?= $this->Html->scriptEnd() ?>
+

--- a/src/Template/Element/common_js_libs.ctp
+++ b/src/Template/Element/common_js_libs.ctp
@@ -42,7 +42,7 @@ echo $this->Html->scriptBlock(
 );
 
 echo $this->Html->scriptBlock(
-    'var tinymce_init_config = ' . json_encode(Configure::read('TinyMCE')) . ';',
+    'var tinymce_init_config = ' . json_encode(Configure::read('CsvMigrations.TinyMCE')) . ';',
     ['block' => 'scriptBottom']
 );
 

--- a/src/Template/Element/common_js_libs.ctp
+++ b/src/Template/Element/common_js_libs.ctp
@@ -41,6 +41,11 @@ echo $this->Html->scriptBlock(
     ['block' => 'scriptBottom']
 );
 
+echo $this->Html->scriptBlock(
+    'var tinymce_init_config = ' . json_encode(Configure::read('TinyMCE')) . ';',
+    ['block' => 'scriptBottom']
+);
+
 echo $this->Html->script(
     [
         'CsvMigrations.dom-observer',
@@ -64,6 +69,8 @@ echo $this->Html->script(
         'AdminLTE./plugins/select2/select2.full.min',
         'CsvMigrations.select2.init',
         'CsvMigrations.plugin',
+        'Qobo/Utils./plugins/tinymce/tinymce.min',
+        'CsvMigrations.tinymce.init',
     ],
     [
         'block' => 'scriptBottom'

--- a/tests/TestCase/FieldHandlers/HtmlFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/HtmlFieldHandlerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace CsvMigrations\Test\TestCase\FieldHandlers;
+
+use CsvMigrations\FieldHandlers\Config\ConfigFactory;
+use CsvMigrations\FieldHandlers\CsvField;
+use CsvMigrations\FieldHandlers\FieldHandler;
+use PHPUnit\Framework\TestCase;
+
+class HtmlFieldHandlerTest extends TestCase
+{
+    protected $table = 'fields';
+    protected $field = 'field_html';
+    protected $type = 'html';
+
+    /** @var \CsvMigrations\FieldHandlers\FieldHandler */
+    protected $fh;
+
+    protected function setUp() : void
+    {
+        $config = ConfigFactory::getByType($this->type, $this->field, $this->table);
+        $this->fh = new FieldHandler($config);
+    }
+
+    public function testFieldToDb() : void
+    {
+        $csvField = new CsvField(['name' => $this->field, 'type' => $this->type]);
+        $fh = $this->fh;
+        $result = $fh::fieldToDb($csvField);
+
+        $this->assertTrue(is_array($result), "fieldToDb() did not return an array");
+        $this->assertFalse(empty($result), "fieldToDb() returned an empty array");
+        $this->assertTrue(array_key_exists($this->field, $result), "fieldToDb() did not return field key");
+        $this->assertTrue(is_object($result[$this->field]), "fieldToDb() did not return object value for field key");
+        $this->assertTrue(is_a($result[$this->field], 'CsvMigrations\FieldHandlers\DbField'), "fieldToDb() did not return DbField instance for field key");
+
+        $this->assertEquals($this->fh->getDbFieldType(), $result[$this->field]->getType(), "fieldToDb() did not return correct type for DbField instance");
+        $this->assertEquals('text', $result[$this->field]->getType(), "fieldToDb() did not return correct hardcoded type for DbField instance");
+        $this->assertGreaterThan(100000000, $result[$this->field]->getLimit(), "fieldToDb() did not return correct limit for DbField instance");
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getValues() : array
+    {
+        return [
+            [true, "1", 'Boolean true'],
+            [false, '', 'Boolean false'],
+            [0, "0", 'Integer zero'],
+            [1, "1", 'Positive integer'],
+            [-1, "-1", 'Negative integer'],
+            [1.501, "1.501", 'Positive float'],
+            [-1.501, "-1.501", 'Negative float'],
+            ['', '', 'Empty string'],
+            ['foobar', "foobar", 'String'],
+            ['<strong>foobar</strong>', "<strong>foobar</strong>", 'Html'],
+            ['2017-07-05', "2017-07-05", 'Date'],
+        ];
+    }
+
+    /**
+     * @dataProvider getValues
+     * @param mixed $value
+     * @param mixed $expected
+     */
+    public function testRenderValue($value, $expected, string $description) : void
+    {
+        $result = $this->fh->renderValue($value, []);
+        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+    }
+
+    public function testRenderValueWithPlainFlag() : void
+    {
+        $result = $this->fh->renderValue('<strong>Hello World!</strong>', ['renderAs' => 'plain']);
+        $this->assertEquals('Hello World!', $result);
+    }
+
+    public function testGetSearchOptions() : void
+    {
+        $result = $this->fh->getSearchOptions();
+
+        $this->assertTrue(is_array($result), "getSearchOptions() did not return an array");
+        $this->assertFalse(empty($result), "getSearchOptions() returned an empty result");
+
+        $this->assertArrayHasKey($this->field, $result, "getSearchOptions() did not return field key");
+
+        $this->assertArrayHasKey('type', $result[$this->field], "getSearchOptions() did not return 'type' key");
+        $this->assertArrayHasKey('label', $result[$this->field], "getSearchOptions() did not return 'label' key");
+        $this->assertArrayHasKey('operators', $result[$this->field], "getSearchOptions() did not return 'operators' key");
+        $this->assertArrayHasKey('input', $result[$this->field], "getSearchOptions() did not return 'input' key");
+
+        $this->assertArrayHasKey('contains', $result[$this->field]['operators'], "getSearchOptions() did not return 'contains' operator");
+        $this->assertArrayHasKey('not_contains', $result[$this->field]['operators'], "getSearchOptions() did not return 'not_contains' operator");
+        $this->assertArrayHasKey('starts_with', $result[$this->field]['operators'], "getSearchOptions() did not return 'starts_with' operator");
+        $this->assertArrayHasKey('ends_with', $result[$this->field]['operators'], "getSearchOptions() did not return 'ends_with' operator");
+    }
+}

--- a/webroot/js/tinymce.init.js
+++ b/webroot/js/tinymce.init.js
@@ -1,0 +1,21 @@
+(function ($) {
+    /**
+     * TinyMCE init
+     */
+    $(document).ready(function () {
+        var config = {};
+        if ('undefined' !== typeof tinymce_init_config) {
+            config = tinymce_init_config;
+        }
+
+        tinyMCE.init(config);
+    });
+
+    // fix issue with link/image pop-up fields not working when tinymce is loaded within bootstrap modal
+    // @link https://github.com/tinymce/tinymce/issues/782#issuecomment-151998981
+    $(document).on('focusin', function (e) {
+        if ($(event.target).closest('.mce-window').length) {
+            e.stopImmediatePropagation();
+        }
+    });
+})(jQuery);


### PR DESCRIPTION
Introduces a new field handler for HTML. For this we are using the tinymce library.

In particular:
* TinyMCE editor is used when rendering the input
* HTML is included as-is when rendering the value
* HTML is stored in db as text
* Searching within HTML is supported