### PR TITLE
Display the correct label when rendering a sublist input (task #9112)

### DIFF
--- a/src/Template/Element/FieldHandlers/SublistFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/SublistFieldHandler/input.ctp
@@ -49,6 +49,7 @@ for ($i = 0; $i <= $levels; $i++) {
         $options['data-selectors'] = json_encode($selectors);
         $options['data-hide-next'] = true;
         $options['data-previous-default-value'] = true;
+        $options['label'] = $label;
     } else {
         $options['label'] = false;
     }


### PR DESCRIPTION
When rendering a sublist input, the custom label for the first input was always ignored. This PR correct this by taking into consideration the provided label, if any