### PR TITLE
Define private methods as protected (task #9745)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -147,7 +147,7 @@ class AppController extends BaseController
      * @return \Cake\Datasource\EntityInterface
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When the record is not found
      */
-    private function fetchEntity(string $id) : EntityInterface
+    protected function fetchEntity(string $id) : EntityInterface
     {
         /** @var \Cake\Datasource\RepositoryInterface&\Cake\ORM\Table */
         $table = $this->loadModel();
@@ -193,7 +193,7 @@ class AppController extends BaseController
      * @param mixed[] $options Patch options
      * @return \Cake\Http\Response|null
      */
-    private function persistEntity(EntityInterface $entity, array $data, array $options = []) : ?Response
+    protected function persistEntity(EntityInterface $entity, array $data, array $options = []) : ?Response
     {
         /** @var \Cake\Datasource\RepositoryInterface&\Cake\ORM\Table */
         $table = $this->loadModel();


### PR DESCRIPTION
- Changing `private` to `protected` visiblity of
  `fetchEntity` and `persistEntity` methods

This would allow us to re-use these methods in application
controllers that inherit `CsvMigrations\AppController` class.