### PR TITLE
Change the direction of the pop-up to "top" (task #10058)

### DIFF
--- a/webroot/js/datetimepicker.init.js
+++ b/webroot/js/datetimepicker.init.js
@@ -81,7 +81,7 @@
                 timePicker: true,
                 minYear: 1900,
                 maxYear: 2050,
-                drops: 'down',
+                drops: 'up',
                 autoUpdateInput: false,
                 timePicker24Hour: true,
                 timePickerIncrement: 5,


### PR DESCRIPTION
- Back-reference to ticket #9839
- Fix resolves an issue with associated/embedded forms that
have its own z-index, and affect datetimepicker, that doesn't
fit the viewpoint.