### PR TITLE
Daterangepicker Magic Values (task #10535)

### DIFF
--- a/webroot/js/datetimepicker.init.js
+++ b/webroot/js/datetimepicker.init.js
@@ -58,6 +58,11 @@
                 // date range picker (used for datetime fields)
                 $(this).daterangepicker(that.getOptions(this, options), that.getCallback(this, hiddenInput));
 
+
+                if ($(this).data('magic-value')) {
+                    $($(this).data('daterangepicker').container).find('.ranges ul').show();
+                }
+
                 $(this).on('apply.daterangepicker', function (ev, picker) {
                     $(this).val(picker.startDate.format(picker.locale.format));
                 });
@@ -98,7 +103,7 @@
             options.locale.format = options.timePicker ? this.format.datetime : this.format.date;
 
             if ($(input).data('magic-value')) {
-                options.ranges = [];
+                options.ranges = {};
                 this.magicValues.forEach(function (item) {
                     // add custom ranges for magic value logic
                     options.ranges[item.name] = item.value;


### PR DESCRIPTION
Daterangepicker disables `ranges` in case following flags are enabled:

* `timePicker` flag is `on`.
* `autoApply` is on and `ranges` object (not array) is not specified.

In our case, for DateTimeFieldHandler we use single Calendar layout,
and pre-populate calendar with magic values (today, yesterday, etc.),
thus we have to force showing custom ranges after daterangepicker
was constructed and magic values object was passed into constructor.

Reference: https://github.com/dangrossman/daterangepicker/blob/v2.1.27/daterangepicker.js#L372