### PR TITLE
Table class missing method for validation per `patchEntity`

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -75,7 +75,7 @@ class Table extends BaseTable implements HasFieldsInterface
     }
 
     /**
-     * Set Table validation rules.
+     * Set Table validation rules if the validation is globally enabled.
      *
      * @param \Cake\Validation\Validator $validator Validator instance
      * @return \Cake\Validation\Validator
@@ -84,9 +84,21 @@ class Table extends BaseTable implements HasFieldsInterface
     {
         // configurable in config/csv_migrations.php
         if (! Configure::read('CsvMigrations.tableValidation')) {
+
             return $validator;
         }
 
+        return $this->validationEnabled($validator);
+    }
+
+    /**
+     * Set Table validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance
+     * @return \Cake\Validation\Validator
+     */
+    public function validationEnabled(Validator $validator) : Validator
+    {
         $className = App::shortName(get_class($this), 'Model/Table', 'Table');
         $config = (new ModuleConfig(ConfigType::MIGRATION(), $className))->parse();
         $config = json_encode($config);

--- a/src/Table.php
+++ b/src/Table.php
@@ -84,7 +84,6 @@ class Table extends BaseTable implements HasFieldsInterface
     {
         // configurable in config/csv_migrations.php
         if (! Configure::read('CsvMigrations.tableValidation')) {
-
             return $validator;
         }
 

--- a/tests/TestCase/TableTest.php
+++ b/tests/TestCase/TableTest.php
@@ -1,0 +1,101 @@
+<?php
+namespace CsvMigrations\Test\TestCase;
+
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Cake\Validation\Validator;
+
+use CsvMigrations\Test\App\Model\Table\FooTable;
+
+/**
+ * CsvMigrations\Table Test Case
+ */
+class TableTest extends TestCase
+{
+    /**
+     * Foo table.
+     * @var \CsvMigrations\Test\App\Model\Table\FooTable
+     */
+    public $Table;
+
+    /**
+     * Default table validation value
+     * @var bool
+     */
+    protected $defaultTableValidation;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.csv_migrations.imports',
+        'plugin.csv_migrations.import_results'
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $this->defaultTableValidation = Configure::readOrFail('CsvMigrations.tableValidation');
+
+        Configure::write('CsvMigrations.modules.path', TESTS . 'config' . DS . 'Modules' . DS);
+        $config = TableRegistry::getTableLocator()->exists('Foo') ? [] : ['className' => FooTable::class];
+        /** @var \CsvMigrations\Test\App\Model\Table\FooTable $table */
+        $table = TableRegistry::getTableLocator()->get('Foo', $config);
+        $this->Table = $table;
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown() : void
+    {
+        Configure::write('CsvMigrations.tableValidation', $this->defaultTableValidation);
+        unset($this->defaultTableValidation);
+        unset($this->Table);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test validationDefault method when table validation is disabled
+     *
+     * @return void
+     */
+    public function testValidationDefaultTableValidationDisabled() : void
+    {
+        Configure::write('CsvMigrations.tableValidation', false);
+        $validator = new Validator();
+        $expected = clone $validator;
+        $validator = $this->Table->validationDefault($validator);
+
+        $this->assertInstanceOf(Validator::class, $validator);
+        $this->assertEquals($expected, $validator, 'Validation class has been modified by table validation.');
+    }
+
+    /**
+     * Test validationDefault method when table validation is enabled
+     *
+     * @return void
+     */
+    public function testValidationDefaultTableValidationEnabled() : void
+    {
+        Configure::write('CsvMigrations.tableValidation', true);
+        $validator = new Validator();
+        $expected = clone $validator;
+        $validator = $this->Table->validationDefault($validator);
+
+        $this->assertInstanceOf(Validator::class, $validator);
+        $this->assertNotEquals($expected, $validator, 'Validation class was not modified by table validation rules.');
+    }
+}


### PR DESCRIPTION
Table class is missing a validation method which can be used per `patchEntity` call, since sometimes enabling table validation system-wide might not be possible.