### PR TITLE
Enabling validation on shell scripts for JSON validation (task #10760)

### DIFF
--- a/src/Utility/Validate/Check/ConfigCheck.php
+++ b/src/Utility/Validate/Check/ConfigCheck.php
@@ -78,7 +78,7 @@ class ConfigCheck extends AbstractCheck
             return $schema;
         });
 
-        $mc->setParser(new Parser($schema, ['lint' => true]));
+        $mc->setParser(new Parser($schema, ['lint' => true, 'validate' => true]));
 
         return $mc;
     }

--- a/src/Utility/Validate/Check/FieldsCheck.php
+++ b/src/Utility/Validate/Check/FieldsCheck.php
@@ -53,7 +53,7 @@ class FieldsCheck extends AbstractCheck
         $mc = new ModuleConfig(ConfigType::FIELDS(), $module, null, ['cacheSkip' => true]);
 
         $schema = $mc->createSchema(['lint' => true]);
-        $mc->setParser(new Parser($schema, ['lint' => true]));
+        $mc->setParser(new Parser($schema, ['lint' => true, 'validate' => true]));
 
         return $mc;
     }

--- a/src/Utility/Validate/Check/MenusCheck.php
+++ b/src/Utility/Validate/Check/MenusCheck.php
@@ -30,7 +30,7 @@ class MenusCheck extends AbstractCheck
         $mc = new ModuleConfig(ConfigType::MENUS(), $module, null, ['cacheSkip' => true]);
 
         $schema = $mc->createSchema(['lint' => true]);
-        $mc->setParser(new Parser($schema, ['lint' => true]));
+        $mc->setParser(new Parser($schema, ['lint' => true, 'validate' => true]));
 
         try {
             $mc->parse();

--- a/src/Utility/Validate/Check/MigrationCheck.php
+++ b/src/Utility/Validate/Check/MigrationCheck.php
@@ -132,7 +132,7 @@ class MigrationCheck extends AbstractCheck
         $mc = new ModuleConfig(ConfigType::MIGRATION(), $module, $configFile, ['cacheSkip' => true]);
 
         $schema = $mc->createSchema(['lint' => true]);
-        $mc->setParser(new Parser($schema, ['lint' => true]));
+        $mc->setParser(new Parser($schema, ['lint' => true, 'validate' => true]));
 
         return $mc;
     }

--- a/src/Utility/Validate/Check/ReportsCheck.php
+++ b/src/Utility/Validate/Check/ReportsCheck.php
@@ -30,7 +30,7 @@ class ReportsCheck extends AbstractCheck
         $mc = new ModuleConfig(ConfigType::REPORTS(), $module, null, ['cacheSkip' => true]);
 
         $schema = $mc->createSchema(['lint' => true]);
-        $mc->setParser(new Parser($schema, ['lint' => true]));
+        $mc->setParser(new Parser($schema, ['lint' => true, 'validate' => true]));
 
         try {
             $mc->parse();

--- a/src/Utility/Validate/Check/ViewsCheck.php
+++ b/src/Utility/Validate/Check/ViewsCheck.php
@@ -225,7 +225,7 @@ class ViewsCheck extends AbstractCheck
             return $schema;
         });
 
-        $mc->setParser(new Parser($schema, ['lint' => true]));
+        $mc->setParser(new Parser($schema, ['lint' => true, 'validate' => true]));
 
         return $mc;
     }


### PR DESCRIPTION
As we disable validation for runtime in https://github.com/QoboLtd/cakephp-utils/pull/183, we're forcing validation on the shell scripts.