### PR TITLE
New look on module title in edit and view pages (task #11436)

### DIFF
--- a/src/Template/Common/add.ctp
+++ b/src/Template/Common/add.ctp
@@ -16,14 +16,18 @@ use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 $config = (new ModuleConfig(ConfigType::MODULE(), $this->name))->parse();
 
-$title = Inflector::singularize(
+$alias = Inflector::singularize(
     isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($this->name))
 );
 
 $options = [
     'entity' => $entity,
     'fields' => $fields,
-    'title' => __('Create {0}', $title),
+    'title' => [
+        'page' => 'Create',
+        'alias' => $alias,
+        'link' => $this->request->getParam('controller')
+    ],
     'handlerOptions' => ['entity' => $this->request],
     'hasPanels' => property_exists($config, 'panels')
 ];

--- a/src/Template/Common/add.ctp
+++ b/src/Template/Common/add.ctp
@@ -16,9 +16,7 @@ use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 $config = (new ModuleConfig(ConfigType::MODULE(), $this->name))->parse();
 
-$alias = Inflector::singularize(
-    isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($this->name))
-);
+$alias = isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($this->name));
 
 $options = [
     'entity' => $entity,

--- a/src/Template/Common/batch.ctp
+++ b/src/Template/Common/batch.ctp
@@ -15,14 +15,10 @@ use Qobo\Utils\ModuleConfig\ConfigType;
 use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 $config = (new ModuleConfig(ConfigType::MODULE(), $this->name))->parse();
-
-$title = __(
-    'Batch edit {0}',
-    isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($this->name))
-);
+$alias = __( isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($this->name)));
 
 $options = [
-    'title' => $title,
+    'title' => ['page' => __('Batch Edit'), 'alias' => $alias, 'link' => $this->request->getParam('controller')],
     'entity' => $entity,
     'fields' => $fields,
     'handlerOptions' => [

--- a/src/Template/Common/edit.ctp
+++ b/src/Template/Common/edit.ctp
@@ -18,9 +18,7 @@ use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 $config = (new ModuleConfig(ConfigType::MODULE(), $this->name))->parse();
 
-$alias = Inflector::singularize(
-    isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($this->name))
-);
+$alias = isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($this->name));
 
 $table = TableRegistry::get(empty($this->plugin) ? $this->name : $this->plugin . '.' . $tableName);
 $displayField = (new FieldHandlerFactory($this))->renderValue(

--- a/src/Template/Common/edit.ctp
+++ b/src/Template/Common/edit.ctp
@@ -10,20 +10,30 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 
+use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use CsvMigrations\FieldHandlers\FieldHandlerFactory;
 use Qobo\Utils\ModuleConfig\ConfigType;
 use Qobo\Utils\ModuleConfig\ModuleConfig;
 
 $config = (new ModuleConfig(ConfigType::MODULE(), $this->name))->parse();
 
-$title = Inflector::singularize(
+$alias = Inflector::singularize(
     isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($this->name))
+);
+
+$table = TableRegistry::get(empty($this->plugin) ? $this->name : $this->plugin . '.' . $tableName);
+$displayField = (new FieldHandlerFactory($this))->renderValue(
+    $table,
+    $table->getDisplayField(),
+    $entity->get($table->getDisplayField()),
+    ['entity' => $entity]
 );
 
 $options = [
     'entity' => $entity,
     'fields' => $fields,
-    'title' => __('Edit {0}', $title),
+    'title' => ['page' => __('Edit {0} ', $displayField), 'alias' => $alias, 'link' => $this->request->getParam('controller')],
     'handlerOptions' => ['entity' => $entity],
     'hasPanels' => property_exists($config, 'panels')
 ];

--- a/src/Template/Element/View/post.ctp
+++ b/src/Template/Element/View/post.ctp
@@ -66,9 +66,19 @@ if (!empty($this->request->getQuery('embedded'))) {
         $formOptions['data-embedded-related-id'] = $this->request->getQuery('related_id');
     }
 }
+
+$linkTitle = is_array($options['title']) ? $this->Html->link(
+            $options['title']['alias'],
+            [
+                'plugin' => $this->plugin,
+                'controller' => $options['title']['link'],
+                'action' => 'index'
+            ]
+        ) . ' &raquo; ' . $options['title']['page'] : (string)$options['title'];
+
 ?>
 <section class="content-header">
-    <h4><?= $options['title'] ?></h4>
+    <h4><?= $linkTitle ?></h4>
 </section>
 <section class="content">
     <?php
@@ -76,6 +86,7 @@ if (!empty($this->request->getQuery('embedded'))) {
      * Conversion logic
      * @todo probably this has to be moved to another plugin
      */
+
     if (!$this->request->getParam('pass.conversion')) {
         echo $this->Form->create($options['entity'], $formOptions);
     }


### PR DESCRIPTION
The title in the view,edit and batch pages of modules has a new format : 
`<ModuleName>  » ( "" || <Edit> || <Batch Edit> ) <entity displayField>`
The ModuleName is a link to the controller of the module.