### PR TITLE
Import improvements (task #11666)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,9 @@ parameters:
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:
             - abort
+    ignoreErrors:
+        # This rule is ignored to avoid aborting early during import shell execution.
+        - '#In method "CsvMigrations\\Shell\\ImportShell::_processData", caught "Exception" must be rethrown.#'
 includes:
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/FieldHandlers/Provider/SearchOptions/ListSearchOptions.php
+++ b/src/FieldHandlers/Provider/SearchOptions/ListSearchOptions.php
@@ -41,7 +41,7 @@ class ListSearchOptions extends AbstractSearchOptions
         $selectOptions = $provider->provide($options['fieldDefinitions']->getLimit());
 
         $view = $this->config->getView();
-        $content = $view->Form->select('{{name}}', $selectOptions, [
+        $content = $view->Form->select('{{name}}', array_merge(['' => Setting::EMPTY_OPTION_LABEL()], $selectOptions), [
             'class' => 'form-control',
             'label' => false
         ]);

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -547,20 +547,16 @@ class ImportShell extends Shell
 
         // check against list options values
         foreach ($options as $val => $params) {
-            if ($val !== $value) {
-                continue;
+            if (strtolower($val) === strtolower(trim($value))) {
+                return $val;
             }
-
-            return $val;
         }
 
         // check against list options labels
         foreach ($options as $val => $params) {
-            if ($params['label'] !== $value) {
-                continue;
+            if (strtolower($params['label']) === strtolower(trim($value))) {
+                return $val;
             }
-
-            return $val;
         }
 
         return $value;

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -456,14 +456,14 @@ class ImportShell extends Shell
                         try {
                             $data[$field] = (new \DateTime($value))->format('Y-m-d H:i:s');
                         } catch (\Exception $e) {
-                            //
+                            // @ignoreException
                         }
                         break;
                     case 'date':
                         try {
                             $data[$field] = (new \DateTime($value))->format('Y-m-d');
                         } catch (\Exception $e) {
-                            //
+                            // @ignoreException
                         }
                         break;
                 }

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -449,6 +449,9 @@ class ImportShell extends Shell
                     case 'country':
                         $data[$field] = $this->_findListValue($table, 'countries', $value);
                         break;
+                    case 'boolean':
+                        $data[$field] = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+                        break;
                 }
             } else {
                 if ('uuid' === $schema->columnType($field)) {

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -452,6 +452,20 @@ class ImportShell extends Shell
                     case 'boolean':
                         $data[$field] = filter_var($value, FILTER_VALIDATE_BOOLEAN);
                         break;
+                    case 'datetime':
+                        try {
+                            $data[$field] = (new \DateTime($value))->format('Y-m-d H:i:s');
+                        } catch (\Exception $e) {
+                            //
+                        }
+                        break;
+                    case 'date':
+                        try {
+                            $data[$field] = (new \DateTime($value))->format('Y-m-d');
+                        } catch (\Exception $e) {
+                            //
+                        }
+                        break;
                 }
             } else {
                 if ('uuid' === $schema->columnType($field)) {

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -468,7 +468,7 @@ class ImportShell extends Shell
                         break;
                 }
             } else {
-                if ('uuid' === $schema->columnType($field)) {
+                if ('uuid' === $schema->getColumnType($field)) {
                     $data[$field] = $this->_findRelatedRecord($table, $field, $value);
                 } else {
                     $data[$field] = $value;

--- a/src/Template/Import/mapping.ctp
+++ b/src/Template/Import/mapping.ctp
@@ -24,8 +24,10 @@ if ($this->plugin) {
 
 $headerOptions = [];
 foreach ($headers as $header) {
-    $key = Inflector::underscore(str_replace(' ', '', trim($header)));
-    $headerOptions[$key] = $header;
+    $headerOptions = array_merge($headerOptions, [
+        strtolower(trim($header)) => $header,
+        Inflector::underscore(str_replace(' ', '', trim($header))) => $header
+    ]);
 }
 
 $options = [
@@ -62,7 +64,6 @@ echo $this->Html->scriptBlock(
 ',
     ['block' => 'scriptBottom']
 );
-
 ?>
 <section class="content-header">
     <div class="row">
@@ -94,6 +95,7 @@ echo $this->Html->scriptBlock(
                         'multiple' => false, // disable multi-selection
                         'magic-value' => false // disable magic values
                     ]);
+
                     // skip fields with no input markup
                     if (! isset($searchOptions[$column]['input']['content'])) {
                         continue;
@@ -104,18 +106,23 @@ echo $this->Html->scriptBlock(
                     <div class="row">
                         <div class="col-md-3">
                             <div class="visible-md visible-lg text-right">
-                                <?= $this->Form->label($label) ?>
+                                <?= $this->Form->label($column, $label) ?>
                             </div>
                             <div class="visible-xs visible-sm">
-                                <?= $this->Form->label($label) ?>
+                                <?= $this->Form->label($column, $label) ?>
                             </div>
                         </div>
                         <div class="col-md-4">
+                            <?php
+                            $selected = false;
+                            $selected = array_key_exists(strtolower($label), $headerOptions) ? $headerOptions[strtolower($label)] : $selected;
+                            $selected = array_key_exists($column, $headerOptions) ? $headerOptions[$column] : $selected;
+                            ?>
                             <?= $this->Form->control('options.fields.' . $column . '.column', [
                                 'empty' => true,
                                 'label' => false,
                                 'type' => 'select',
-                                'value' => array_key_exists($column, $headerOptions) ? $headerOptions[$column] : false,
+                                'value' => $selected,
                                 'options' => array_combine($headers, $headers),
                                 'class' => 'form-control select2'
                             ]) ?>

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -17,6 +17,8 @@ class ArticlesFixture extends TestFixture
         'author' => ['type' => 'string', 'length' => 36, 'null' => true],
         'status' => ['type' => 'string', 'length' => 100, 'null' => true],
         'main_article' => ['type' => 'uuid', 'null' => true],
+        'date' => ['type' => 'date', 'null' => true],
+        'featured' => ['type' => 'boolean', 'null' => true],
         'image' => ['type' => 'uuid', 'null' => true],
         'created' => ['type' => 'datetime', 'null' => true],
         'modified' => ['type' => 'datetime', 'null' => true],

--- a/tests/Fixture/ImportResultsFixture.php
+++ b/tests/Fixture/ImportResultsFixture.php
@@ -86,7 +86,7 @@ class ImportResultsFixture extends TestFixture
             'row_number' => 3,
             'model_name' => 'Articles',
             'model_id' => null,
-            'status' => 'Success',
+            'status' => 'Pending',
             'status_message' => 'Lorem ipsum dolor sit amet, aliquet feugiat.',
             'created' => '2017-07-31 17:10:39',
             'modified' => '2017-07-31 17:10:39',

--- a/tests/Fixture/ImportsFixture.php
+++ b/tests/Fixture/ImportsFixture.php
@@ -62,7 +62,7 @@ class ImportsFixture extends TestFixture
         [
             'id' => '00000000-0000-0000-0000-000000000002',
             'filename' => TESTS . 'uploads' . DS . 'imports' . DS . 'articles.csv',
-            'options' => '{"fields":{"name":{"column":"Name","default":""},"author":{"column":"Author","default":""},"status":{"column":"Status","default":""}}}',
+            'options' => '{"fields":{"name":{"column":"Name","default":""},"author":{"column":"Author","default":""},"status":{"column":"Status","default":""},"featured":{"column":"Featured","default":""},"date":{"column":"Date","default":""}}}',
             'created' => '2017-08-01 11:06:06',
             'modified' => '2017-08-01 11:06:06',
             'trashed' => null,

--- a/tests/TestCase/Controller/Traits/ImportIntegrationTest.php
+++ b/tests/TestCase/Controller/Traits/ImportIntegrationTest.php
@@ -55,8 +55,8 @@ class ImportIntegrationTest extends IntegrationTestCase
 
         $this->assertInstanceOf(Import::class, $this->viewVariable('import'));
 
-        $this->assertEquals(['name', 'category', 'author', 'status', 'main_article', 'image'], $this->viewVariable('columns'));
-        $this->assertEquals(['Name', 'Author', 'Status'], $this->viewVariable('headers'));
+        $this->assertEquals(['name', 'category', 'author', 'status', 'main_article', 'date', 'featured', 'image'], $this->viewVariable('columns'));
+        $this->assertEquals(['Name', 'Author', 'Status', 'Featured', 'Date'], $this->viewVariable('headers'));
     }
 
     public function testImportGetExistingMapped() : void
@@ -68,8 +68,8 @@ class ImportIntegrationTest extends IntegrationTestCase
         $this->assertInstanceOf(Import::class, $this->viewVariable('import'));
 
         $this->assertEquals(1, $this->viewVariable('failCount'));
-        $this->assertEquals(1, $this->viewVariable('pendingCount'));
-        $this->assertEquals(1, $this->viewVariable('importCount'));
+        $this->assertEquals(2, $this->viewVariable('pendingCount'));
+        $this->assertEquals(0, $this->viewVariable('importCount'));
     }
 
     public function testImportPost() : void

--- a/tests/TestCase/FieldHandlers/DateFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DateFieldHandlerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace CsvMigrations\Test\TestCase\FieldHandlers;
 
+use Cake\I18n\Date;
 use Cake\I18n\Time;
 use CsvMigrations\FieldHandlers\Config\ConfigFactory;
 use CsvMigrations\FieldHandlers\CsvField;
@@ -49,6 +50,7 @@ class DateFieldHandlerTest extends TestCase
             ['foobar', 'foobar', 'Non-date string'],
             [15, 15, 'Non-date integer'],
             [Time::parse('2017-07-06 14:20:00'), '2017-07-06', 'Date from object'],
+            [new Date('2017-07-06 14:20:00'), '2017-07-06', 'Date from object'],
         ];
     }
 

--- a/tests/TestCase/FieldHandlers/DatetimeFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/DatetimeFieldHandlerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace CsvMigrations\Test\TestCase\FieldHandlers;
 
+use Cake\I18n\Date;
 use Cake\I18n\Time;
 use CsvMigrations\FieldHandlers\Config\ConfigFactory;
 use CsvMigrations\FieldHandlers\CsvField;
@@ -49,6 +50,7 @@ class DatetimeFieldHandlerTest extends TestCase
             ['foobar', 'foobar', 'Non-date string'],
             [15, 15, 'Non-date integer'],
             [Time::parse('2017-07-06 14:20:00'), '2017-07-06 14:20', 'Date time from object'],
+            [new Date('2017-07-06 14:20:00'), '2017-07-06 00:00', 'Date time from object'],
         ];
     }
 

--- a/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
@@ -74,16 +74,16 @@ class TimeFieldHandlerTest extends TestCase
 
     public function testRenderInputWithTimeObject() : void
     {
-        $result = $this->fh->renderInput(new Time('13:30'));
+        $result = $this->fh->renderInput(new Time('13:30:00'));
 
         $this->assertContains('value="13:30"', $result);
     }
 
     public function testRenderInputWithDateObject() : void
     {
-        $result = $this->fh->renderInput(new Date('13:30'));
+        $result = $this->fh->renderInput(new Date('13:30:00'));
 
-        $this->assertContains('value="13:30"', $result);
+        $this->assertContains('value="00:00"', $result);
     }
 
     public function testGetSearchOptions() : void

--- a/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/TimeFieldHandlerTest.php
@@ -66,17 +66,17 @@ class TimeFieldHandlerTest extends TestCase
 
     public function testRenderInput() : void
     {
-        $result = $this->fh->renderInput('13:30');
-        $this->assertRegExp('/field_time/', $result, "Input rendering does not contain field name");
+        $result = $this->fh->renderInput('13:30:00');
+        $this->assertContains('name="' . $this->table . '[' . $this->field . ']"', $result);
+        $this->assertContains('data-provide="timepicker"', $result);
+        $this->assertContains('value="13:30:00"', $result);
     }
 
     public function testRenderInputWithTimeObject() : void
     {
         $result = $this->fh->renderInput(new Time('13:30'));
 
-        $this->assertContains('name="' . $this->table . '[' . $this->field . ']"', $result);
         $this->assertContains('value="13:30"', $result);
-        $this->assertContains('data-provide="timepicker"', $result);
     }
 
     public function testRenderInputWithDateObject() : void

--- a/tests/TestCase/Utility/FieldTest.php
+++ b/tests/TestCase/Utility/FieldTest.php
@@ -51,7 +51,7 @@ class FieldTest extends TestCase
         $table = TableRegistry::get('Articles');
 
         $result = Field::getCsv($table);
-        $expected = ['id', 'name', 'status', 'author', 'main_article', 'category', 'image', 'created', 'modified'];
+        $expected = ['id', 'name', 'status', 'author', 'main_article', 'date', 'featured', 'category', 'image', 'created', 'modified'];
         $this->assertSame($expected, array_keys($result));
 
         foreach ($result as $csvField) {

--- a/tests/TestCase/Utility/ImportTest.php
+++ b/tests/TestCase/Utility/ImportTest.php
@@ -45,7 +45,7 @@ class ImportTest extends TestCase
             [1, 'Success', 'Lorem ipsum dolor sit amet, aliquet feugiat.'],
             [1, 'Fail', 'Lorem ipsum dolor sit amet, aliquet feugiat.'],
             [2, 'Pending', 'Lorem ipsum dolor sit amet, aliquet feugiat.'],
-            [3, 'Success', 'Lorem ipsum dolor sit amet, aliquet feugiat.']
+            [3, 'Pending', 'Lorem ipsum dolor sit amet, aliquet feugiat.']
         ];
         $result = Import::toDatatables($query->all(), $columns);
 

--- a/tests/config/Modules/Articles/db/migration.json
+++ b/tests/config/Modules/Articles/db/migration.json
@@ -34,6 +34,20 @@
         "non-searchable": false,
         "unique": false
     },
+    "date": {
+        "name": "date",
+        "type": "date",
+        "required": false,
+        "non-searchable": false,
+        "unique": false
+    },
+    "featured": {
+        "name": "featured",
+        "type": "boolean",
+        "required": false,
+        "non-searchable": false,
+        "unique": false
+    },
     "category": {
         "name": "category",
         "type": "related(Categories)",

--- a/tests/uploads/imports/articles-with-invalid-dates.csv
+++ b/tests/uploads/imports/articles-with-invalid-dates.csv
@@ -1,0 +1,3 @@
+Name,Date
+Foo [import],06-30-2019
+Bar [import],1,30/06/2019

--- a/tests/uploads/imports/articles-with-invalid-dates.processed.csv
+++ b/tests/uploads/imports/articles-with-invalid-dates.processed.csv
@@ -1,0 +1,3 @@
+Name,Date
+"Foo [import]",06-30-2019
+"Bar [import]",1,30/06/2019

--- a/tests/uploads/imports/articles.csv
+++ b/tests/uploads/imports/articles.csv
@@ -1,3 +1,6 @@
-Name,Author,Status
-John Doe [import],00000000-0000-0000-0000-000000000001,Draft
-John Smith [import],Author - 2,Published
+Name,Author,Status,Featured,Date
+John Doe [import],00000000-0000-0000-0000-000000000001,Draft,Yes,2019-06-30
+John Smith [import],Author - 2,Published ,no,5-6-2019
+Michael Cain [import],Author - 1,DraFt,NO,2019/4/13
+John Kemp [import],Author - 1,Draft ,on,6/22/19
+Michael Johnson [import],00000000-0000-0000-0000-000000000002,PUBLISHED,1,3.2.2019

--- a/tests/uploads/imports/articles.processed.csv
+++ b/tests/uploads/imports/articles.processed.csv
@@ -1,3 +1,6 @@
-Name,Author,Status
-"John Doe [import]",00000000-0000-0000-0000-000000000001,Draft
-"John Smith [import]","Author - 2",Published
+Name,Author,Status,Featured,Date
+"John Doe [import]",00000000-0000-0000-0000-000000000001,Draft,Yes,2019-06-30
+"John Smith [import]","Author - 2","Published ",no,5-6-2019
+"Michael Cain [import]","Author - 1",DraFt,NO,2019/4/13
+"John Kemp [import]","Author - 1","Draft ",on,6/22/19
+"Michael Johnson [import]",00000000-0000-0000-0000-000000000002,PUBLISHED,1,3.2.2019


### PR DESCRIPTION
Improvements:
- Extended import shell tests.
- Improved list option detection during import shell execution. It does so by trimming and converting to lowercase the value provided from the CSV and compares it to the lowercased options of the provided list. 
- Added support for converting strings such as _yes_, _no_ to boolean.
- Added support for converting valid date formats to MySQL default format.
- Improved automatic field mapping on import screen, by checking for matching CSV column header to a field label.
- Re-added empty option for list-type fields, as it is required for import mapping defaults.