### PR TITLE
Mark deprecates views and controller (Task #7507)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
     stopOnFailure="false"
     bootstrap="./tests/bootstrap.php"
     verbose="true"
+    convertDeprecationsToExceptions="false"
     >
     <php>
         <ini name="memory_limit" value="-1"/>

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -11,6 +11,11 @@
  */
 namespace CsvMigrations\Controller;
 
+deprecationWarning(
+    '"CsvMigrations\Controller" class is deprecated. This functionality is ' .
+    'now handled by "\App\Controller\BaseModuleController"'
+);
+
 use App\Controller\AppController as BaseController;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;

--- a/src/Template/Common/add.ctp
+++ b/src/Template/Common/add.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.View/add" view is deprecated.');
 
 use Cake\Utility\Inflector;
 use Qobo\Utils\ModuleConfig\ConfigType;

--- a/src/Template/Common/batch.ctp
+++ b/src/Template/Common/batch.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.View/batch" view is deprecated.');
 
 use Cake\Utility\Inflector;
 use Qobo\Utils\ModuleConfig\ConfigType;

--- a/src/Template/Common/edit.ctp
+++ b/src/Template/Common/edit.ctp
@@ -10,6 +10,8 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 
+deprecationWarning('"CsvMigrations.View/edit" view is deprecated.');
+
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;

--- a/src/Template/Common/view.ctp
+++ b/src/Template/Common/view.ctp
@@ -9,8 +9,10 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.View/view" view is deprecated.');
 
 use Cake\Utility\Inflector;
+
 
 $options = [
     'entity' => $entity,

--- a/src/Template/Element/Associated/modals.ctp
+++ b/src/Template/Element/Associated/modals.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Associated/modal" view is deprecated.');
 
 use Cake\Utility\Inflector;
 use Cake\ORM\TableRegistry;

--- a/src/Template/Element/Associated/tab-content.ctp
+++ b/src/Template/Element/Associated/tab-content.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Associated/tab-content" view is deprecated.');
 
 use Cake\Core\Configure;
 use Cake\Utility\Inflector;

--- a/src/Template/Element/Associated/tabs-content.ctp
+++ b/src/Template/Element/Associated/tabs-content.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Associated/tabs-content" view is deprecated.');
 
 use Cake\Utility\Inflector;
 ?>

--- a/src/Template/Element/Associated/tabs-list.ctp
+++ b/src/Template/Element/Associated/tabs-list.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Associated/tabs-list" view is deprecated.');
 
 use Cake\Utility\Inflector;
 ?>

--- a/src/Template/Element/Embedded/fields.ctp
+++ b/src/Template/Element/Embedded/fields.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Embedded/fields" view is deprecated.');
 
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Http\Exception\ForbiddenException;

--- a/src/Template/Element/Embedded/lookup.ctp
+++ b/src/Template/Element/Embedded/lookup.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Embedded/lookup" view is deprecated.');
 
 use Cake\Utility\Inflector;
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;

--- a/src/Template/Element/Embedded/modals.ctp
+++ b/src/Template/Element/Embedded/modals.ctp
@@ -9,6 +9,8 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
+deprecationWarning('"CsvMigrations.Embedded/modals" view is deprecated.');
 ?>
 <?php foreach ($fields as $field) : ?>
     <?php

--- a/src/Template/Element/Field/input.ctp
+++ b/src/Template/Element/Field/input.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Field/input" view is deprecated.');
 
 use CsvMigrations\FieldHandlers\CsvField;
 use Cake\ORM\TableRegistry;

--- a/src/Template/Element/Field/value.ctp
+++ b/src/Template/Element/Field/value.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Field/value" view is deprecated.');
 
 use CsvMigrations\FieldHandlers\CsvField;
 use Cake\ORM\TableRegistry;

--- a/src/Template/Element/Form/fields.ctp
+++ b/src/Template/Element/Form/fields.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Form/fields" view is deprecated.');
 
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;
 

--- a/src/Template/Element/Form/fields_embedded.ctp
+++ b/src/Template/Element/Form/fields_embedded.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Form/fields_embedded" view is deprecated.');
 
 use CsvMigrations\FieldHandlers\CsvField;
 
@@ -37,7 +38,7 @@ foreach ($fields as $panelFields) {
             }else{
                 $associationFields[] = $field;
             }
-            
+
         }
     }
 }

--- a/src/Template/Element/Form/fields_panel.ctp
+++ b/src/Template/Element/Form/fields_panel.ctp
@@ -9,6 +9,8 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
+deprecationWarning('"CsvMigrations.Form/fields_panel" view is deprecated.');
 ?>
 <?php foreach ($panelFields as $subFields) : ?>
     <?php $fieldCount = 12 < count($subFields) ? 12 : count($subFields); ?>

--- a/src/Template/Element/Menu/view_top.ctp
+++ b/src/Template/Element/Menu/view_top.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.Menu/view_top" view is deprecated.');
 
 use CsvMigrations\FieldHandlers\FieldHandlerFactory;
 

--- a/src/Template/Element/View/associated.ctp
+++ b/src/Template/Element/View/associated.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.View/associated" view is deprecated.');
 
 use Cake\ORM\Association;
 

--- a/src/Template/Element/View/post.ctp
+++ b/src/Template/Element/View/post.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.View/post" view is deprecated.');
 
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;

--- a/src/Template/Element/View/view.ctp
+++ b/src/Template/Element/View/view.ctp
@@ -9,6 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+deprecationWarning('"CsvMigrations.View/view" view is deprecated.');
 
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;


### PR DESCRIPTION
The following views and controller are moved in the `project-template-cakephp` :
```src/Controller/AppController.php
src/Template/Common/add.ctp
src/Template/Common/batch.ctp
src/Template/Common/edit.ctp
src/Template/Common/view.ctp
src/Template/Element/Associated/modals.ctp
src/Template/Element/Associated/tab-content.ctp
src/Template/Element/Associated/tabs-content.ctp
src/Template/Element/Associated/tabs-list.ctp
src/Template/Element/Embedded/fields.ctp
src/Template/Element/Embedded/lookup.ctp
src/Template/Element/Embedded/modals.ctp
src/Template/Element/Field/input.ctp
src/Template/Element/Field/value.ctp
src/Template/Element/Form/fields.ctp
src/Template/Element/Form/fields_embedded.ctp
src/Template/Element/Form/fields_panel.ctp
src/Template/Element/Menu/view_top.ctp
src/Template/Element/View/associated.ctp
src/Template/Element/View/post.ctp
src/Template/Element/View/view.ctp```
