### PR TITLE
Do not cast to string array fields (Task #12795)

### DIFF
--- a/src/FieldHandlers/Provider/RenderValue/AbstractRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/AbstractRenderer.php
@@ -32,7 +32,11 @@ abstract class AbstractRenderer extends AbstractProvider
     public function provide($data = null, array $options = [])
     {
         // TODO: need to handle this better, type-casting to string will produce errors
-        $result = (string)$data;
+        if (!is_array($data)) {
+            $result = (string)$data;
+        } else {
+            $result = '';
+        }
 
         if (empty($result)) {
             return $result;

--- a/src/FieldHandlers/Provider/RenderValue/DatetimeRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/DatetimeRenderer.php
@@ -47,6 +47,13 @@ class DatetimeRenderer extends AbstractRenderer
             $options['format'] = static::FORMAT;
         }
 
+        /**
+         * Return if $data is array
+         */
+        if (is_array($data)) {
+            return '';
+        }
+
         // Format object timestamp
         if (is_object($data)) {
             if (method_exists($data, 'i18nFormat') && is_callable([$data, 'i18nFormat'])) {

--- a/src/FieldHandlers/Provider/RenderValue/EmailRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/EmailRenderer.php
@@ -29,7 +29,15 @@ class EmailRenderer extends AbstractRenderer
      */
     public function provide($data = null, array $options = [])
     {
-        $result = (string)$data;
+
+        /**
+         * Return if $data is array
+         */
+        if (is_array($data)) {
+            return '';
+        } else {
+            $result = (string)$data;
+        }
 
         if (empty($result)) {
             return $result;

--- a/src/FieldHandlers/Provider/RenderValue/EmailRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/EmailRenderer.php
@@ -29,7 +29,6 @@ class EmailRenderer extends AbstractRenderer
      */
     public function provide($data = null, array $options = [])
     {
-
         /**
          * Return if $data is array
          */

--- a/src/FieldHandlers/Provider/RenderValue/LinkRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/LinkRenderer.php
@@ -42,7 +42,14 @@ class LinkRenderer extends AbstractRenderer
      */
     public function provide($data = null, array $options = [])
     {
-        $result = (string)$data;
+        /**
+         * Return if $data is array
+         */
+        if (is_array($data)) {
+            return '';
+        } else {
+            $result = (string)$data;
+        }
 
         if (empty($result)) {
             return $result;

--- a/src/FieldHandlers/Provider/RenderValue/NumberRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/NumberRenderer.php
@@ -39,6 +39,14 @@ class NumberRenderer extends AbstractRenderer
      */
     public function provide($data = null, array $options = [])
     {
+
+        /**
+         * Return if $data is array
+         */
+        if (is_array($data)) {
+            return '0';
+        }
+
         // Sanitize
         $number = filter_var($data, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
 

--- a/src/FieldHandlers/Provider/RenderValue/NumberRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/NumberRenderer.php
@@ -39,7 +39,6 @@ class NumberRenderer extends AbstractRenderer
      */
     public function provide($data = null, array $options = [])
     {
-
         /**
          * Return if $data is array
          */

--- a/src/FieldHandlers/Provider/RenderValue/UrlRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/UrlRenderer.php
@@ -39,7 +39,14 @@ class UrlRenderer extends AbstractRenderer
      */
     public function provide($data = null, array $options = [])
     {
-        $result = (string)$data;
+        /**
+         * Return if $data is array
+         */
+        if (is_array($data)) {
+            return '';
+        } else {
+            $result = (string)$data;
+        }
 
         if (empty($result)) {
             return $result;

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/BooleanOnOffRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/BooleanOnOffRendererTest.php
@@ -33,6 +33,7 @@ class BooleanOnOffRendererTest extends TestCase
             [0, 'Off', 'Integer false'],
             ['1', 'On', 'String true'],
             ['0', 'Off', 'String false'],
+            [[], 'Off', 'Array Value'],
         ];
     }
 
@@ -44,7 +45,7 @@ class BooleanOnOffRendererTest extends TestCase
     public function testRenderValue($value, $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValueLabels() : void

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/BooleanRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/BooleanRendererTest.php
@@ -33,6 +33,7 @@ class BooleanRendererTest extends TestCase
             [0, '0', 'Integer false'],
             ['1', '1', 'String true'],
             ['0', '0', 'String false'],
+            [[], '0', 'Array Value'],
         ];
     }
 
@@ -44,7 +45,7 @@ class BooleanRendererTest extends TestCase
     public function testRenderValue($value, $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValueLabels() : void

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/BooleanYesNoRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/BooleanYesNoRendererTest.php
@@ -33,6 +33,7 @@ class BooleanYesNoRendererTest extends TestCase
             [0, 'No', 'Integer false'],
             ['1', 'Yes', 'String true'],
             ['0', 'No', 'String false'],
+            [[], 'No', 'Array Value'],
         ];
     }
 
@@ -44,7 +45,7 @@ class BooleanYesNoRendererTest extends TestCase
     public function testRenderValue($value, $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValueLabels() : void

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/DateRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/DateRendererTest.php
@@ -36,6 +36,7 @@ class DateRendererTest extends TestCase
             [15, '15', 'Non-date integer'],
             [null, '', 'Null'],
             [Time::parse('2017-07-06 14:20:00'), '2017-07-06', 'Date from object'],
+            [[], '', 'Array Value'],
         ];
     }
 
@@ -47,7 +48,7 @@ class DateRendererTest extends TestCase
     public function testRenderValue($value, $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValueFormat() : void

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/DateTimeRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/DateTimeRendererTest.php
@@ -36,6 +36,7 @@ class DateTimeRendererTest extends TestCase
             [15, '15', 'Non-date integer'],
             [null, '', 'Null'],
             [Time::parse('2017-07-06 14:20:00'), '2017-07-06 14:20', 'Date time from object'],
+            [[], '', 'Array Value'],
         ];
     }
 
@@ -47,7 +48,7 @@ class DateTimeRendererTest extends TestCase
     public function testRenderValue($value, $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValueFormat() : void

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/DblistRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/DblistRendererTest.php
@@ -49,7 +49,7 @@ class DblistRendererTest extends TestCase
     public function testRenderValueBasic(string $value, string $expected, string $description) : void
     {
         $result = $this->renderer->provide($value, ['listName' => null]);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValue() : void

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/EmailRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/EmailRendererTest.php
@@ -38,6 +38,7 @@ class EmailRendererTest extends TestCase
             ['foobar', 'foobar', 'String'],
             ['2017-07-05', '2017-07-05', 'Date'],
             ['user@example.com', '<a href="mailto:user@example.com" target="_blank">user@example.com</a>', 'Email'],
+            [[], '', 'Array Value'],
         ];
     }
 

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/FilesRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/FilesRendererTest.php
@@ -52,6 +52,7 @@ class FilesRendererTest extends TestCase
             [-1, ''],
             ['', ''],
             ['foobar', ''],
+            [[], '', 'Array Value'],
         ];
     }
 

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/IntegerRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/IntegerRendererTest.php
@@ -37,6 +37,7 @@ class IntegerRendererTest extends TestCase
             ['foobar', '0', 'String'],
             ['foobar15', '15', 'String with number'],
             ['2017-07-05', '2,017', 'Date'],
+            [[], '0', 'Array Value'],
         ];
     }
 

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/LinkRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/LinkRendererTest.php
@@ -40,6 +40,7 @@ class LinkRendererTest extends TestCase
             ['2017-07-05', '2017-07-05', 'Date'],
             ['www.google.com', 'www.google.com', 'URL without schema'],
             ['/foobar', '/foobar', 'Relative URL that starts with a slash'],
+            [[], '', 'Array Value'],
         ];
     }
 
@@ -50,7 +51,7 @@ class LinkRendererTest extends TestCase
     public function testRenderValue($value, string $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValueWithOptions() : void

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/ListRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/ListRendererTest.php
@@ -39,7 +39,7 @@ class ListRendererTest extends TestCase
     public function testRenderValueBasic(string $value, string $expected, string $description) : void
     {
         $result = $this->renderer->provide($value, ['listItems' => [ $value => $expected ] ]);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValueZeroInt() : void

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/PlainRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/PlainRendererTest.php
@@ -37,6 +37,7 @@ class PlainRendererTest extends TestCase
             ['', '', 'Empty string'],
             ['foobar', 'foobar', 'String'],
             ['2017-07-05', '2017-07-05', 'Date'],
+            [[], '', 'Array Value'],
         ];
     }
 
@@ -47,6 +48,6 @@ class PlainRendererTest extends TestCase
     public function testRenderValue($value, string $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 }

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/StringRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/StringRendererTest.php
@@ -37,6 +37,7 @@ class StringRendererTest extends TestCase
             ['', '', 'Empty string'],
             ['foobar', 'foobar', 'String'],
             ['2017-07-05', '2017-07-05', 'Date'],
+            [[], '', 'Array Value'],
         ];
     }
 
@@ -47,6 +48,6 @@ class StringRendererTest extends TestCase
     public function testRenderValue($value, string $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 }

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/TextRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/TextRendererTest.php
@@ -37,6 +37,7 @@ class TextRendererTest extends TestCase
             ['', '', 'Empty string'],
             ['foobar', "<p>foobar</p>\n", 'String'],
             ['2017-07-05', "<p>2017-07-05</p>\n", 'Date'],
+            [[], '', 'Array Value'],
         ];
     }
 

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/TimeRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/TimeRendererTest.php
@@ -36,6 +36,7 @@ class TimeRendererTest extends TestCase
             [15, '15', 'Non-date integer'],
             [null, '', 'Null'],
             [Time::parse('2017-07-06 14:20:00'), '14:20', 'Time from object'],
+            [[], '', 'Array Value'],
         ];
     }
 
@@ -46,7 +47,7 @@ class TimeRendererTest extends TestCase
     public function testRenderValue($value, string $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValueFormat() : void

--- a/tests/TestCase/FieldHandlers/Provider/RenderValue/UrlRendererTest.php
+++ b/tests/TestCase/FieldHandlers/Provider/RenderValue/UrlRendererTest.php
@@ -39,6 +39,7 @@ class UrlRendererTest extends TestCase
             ['2017-07-05', '2017-07-05', 'Date'],
             ['www.google.com', 'www.google.com', 'URL without schema'],
             ['http://www.google.com', '<a href="http://www.google.com" target="_blank">http://www.google.com</a>', 'URL with schema'],
+            [[], '', 'Array Value'],
         ];
     }
 
@@ -50,7 +51,7 @@ class UrlRendererTest extends TestCase
     public function testRenderValue($value, $expected, string $description) : void
     {
         $result = $this->renderer->provide($value);
-        $this->assertEquals($expected, $result, "Value rendering is broken for: $description");
+        $this->assertSame($expected, $result, "Value rendering is broken for: $description");
     }
 
     public function testRenderValueWithOptions() : void


### PR DESCRIPTION
If the field is array it cannot be cast to string so we return and we do not proceed to render the field.