### PR TITLE
Timepicker bugfix (task #10976)

### DIFF
--- a/webroot/js/timepicker.init.js
+++ b/webroot/js/timepicker.init.js
@@ -41,11 +41,11 @@
             }
 
             // time picker
-            $('[data-provide="timepicker"]').timepicker(defaults).on('changeTime.timepicker show.timepicker', function(e) {
+            $('[data-provide="timepicker"]').timepicker(defaults).on('changeTime.timepicker show.timepicker', function (e) {
                 // bugfix to prevent one digit hour
-                if(e.time.hours < 10) {
+                if (e.time.hours < 10) {
                         $(e.currentTarget).val('0' + e.time.hours + ':' + e.time.minutes);
-                    }
+                }
             });
 
         }

--- a/webroot/js/timepicker.init.js
+++ b/webroot/js/timepicker.init.js
@@ -17,6 +17,7 @@
                 });
             });
         });
+        $("body").find('[data-provide="timepicker"]').data('timepicker').update()
     }
 
     TimePicker.prototype = {
@@ -40,7 +41,13 @@
             }
 
             // time picker
-            $('[data-provide="timepicker"]').timepicker(defaults);
+            $('[data-provide="timepicker"]').timepicker(defaults).on('changeTime.timepicker show.timepicker', function(e) {
+                // bugfix to prevent one digit hour
+                if(e.time.hours < 10) {
+                        $(e.currentTarget).val('0' + e.time.hours + ':' + e.time.minutes);
+                    }
+            });
+
         }
     };
 


### PR DESCRIPTION
In case the project runs with the `CsvMigrations.tableValidation` enabled, the cakephp validation were failing due the wrong format of the hours in the time (*H* instead of *HH*). 
The `bootstrap-timepicker` JS library responsible to provide the time is no longer maintained and a small workaround is set to provide always two digit hours.