### PR TITLE
Avoid huge Thumbnails for non-images files (task #11694)

### DIFF
--- a/src/Template/Element/FieldHandlers/FilesFieldHandler/value.ctp
+++ b/src/Template/Element/FieldHandlers/FilesFieldHandler/value.ctp
@@ -37,7 +37,7 @@ $limit = 3;
             <div class="thumbnail" title="<?= $entity->get('filename') ?>">
                 <?= $this->Html->image(Hash::get(
                     $entity->get('thumbnails'),
-                    in_array($entity->extension, FileUpload::IMAGE_EXTENSIONS) ? 'small' : 'huge'
+                    in_array($entity->extension, FileUpload::IMAGE_EXTENSIONS) ? 'small' : 'large'
                 )) ?>
                 <div class="caption">
                     <p class="small text-center no-margin" style="white-space: nowrap; text-overflow: ellipsis;overflow: hidden;">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40852083/64002030-cc101780-cb11-11e9-8c5a-75e92e1285ab.png)
