### PR TITLE
Self related associations (task #10468)

### DIFF
--- a/src/Model/AssociationsAwareTrait.php
+++ b/src/Model/AssociationsAwareTrait.php
@@ -244,6 +244,12 @@ trait AssociationsAwareTrait
          */
         if ($field->getAssocCsvModule() === $module) {
             $className = $module;
+            // Set self related association
+            $this->setAssociation(
+                'hasMany',
+                static::generateAssociationName($field->getName(), $className),
+                ['className' => $className, 'foreignKey' => $field->getName()]
+            );
             $associationType = 'belongsTo';
         }
 

--- a/tests/TestCase/Model/AssociationsAwareTraitTest.php
+++ b/tests/TestCase/Model/AssociationsAwareTraitTest.php
@@ -82,6 +82,7 @@ class AssociationsAwareTraitTest extends TestCase
             ['Articles', 'AuthorAuthors', BelongsTo::class],
             ['Articles', 'CategoryCategories', BelongsTo::class],
             ['Articles', 'ImageFileStorageFileStorage', HasMany::class],
+            ['Articles', 'Articlesmain_article', HasMany::class],
             ['Articles', 'MainArticleArticles', BelongsTo::class],
             ['Articles', 'MainArticleIdSimilarArticles', BelongsToMany::class, 'similar_articles'],
             ['Articles', 'SimilarArticleIdSimilarArticles', BelongsToMany::class, 'similar_articles'],


### PR DESCRIPTION
Self related tables need to have a one more association to work correctly : assuming that table "Articles" has a related field `related(Articles)`, then a single record can have multiple "sub" articles.