### PR TITLE
Fix api controller url for lookup search (task #13292)

### DIFF
--- a/src/FieldHandlers/Provider/SearchOptions/RelatedSearchOptions.php
+++ b/src/FieldHandlers/Provider/SearchOptions/RelatedSearchOptions.php
@@ -81,7 +81,7 @@ class RelatedSearchOptions extends AbstractSearchOptions
         );
 
         $result[$field]['display_field'] = $relatedProperties['displayField'];
-        $result[$field]['source'] = Inflector::tableize($relatedProperties['controller']);
+        $result[$field]['source'] = Inflector::dasherize($relatedProperties['controller']);
         $result[$field]['url'] = $view->Url->build([
             'prefix' => 'api',
             'plugin' => $relatedProperties['plugin'],


### PR DESCRIPTION
The correct url in the search page for lookup in related fields is `/api/controller-name` and not `/api/controller_name`.