### PR TITLE
iCalendar email improvements (task #5418)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Project specific files #
 ##########################
 build/
+/tmp/
 vendor/
 cghooks.lock
 

--- a/src/Event/Model/ModelAfterSaveListener.php
+++ b/src/Event/Model/ModelAfterSaveListener.php
@@ -277,11 +277,18 @@ class ModelAfterSaveListener implements EventListenerInterface
      */
     protected function isRequiredModified(EntityInterface $entity, array $requiredFields, Table $table) : bool
     {
+        Assert::isInstanceOf($entity, \Cake\ORM\Entity::class);
+
         foreach ($requiredFields as $field) {
             if (! $entity->isDirty($field)) {
                 continue;
             }
+
             $columnType = $table->getSchema()->getColumnType($field);
+            if (null === $columnType) {
+                continue;
+            }
+
             $toPHP = Type::build($columnType)->toPHP($entity->get($field), $table->getConnection()->getDriver());
 
             // loose comparison on purpose

--- a/src/Event/Model/ModelAfterSaveListener.php
+++ b/src/Event/Model/ModelAfterSaveListener.php
@@ -12,6 +12,7 @@
 namespace CsvMigrations\Event\Model;
 
 use BadMethodCallException;
+use Cake\Database\Type;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Datasource\RepositoryInterface;
@@ -127,7 +128,7 @@ class ModelAfterSaveListener implements EventListenerInterface
         $requiredFields = array_merge((array)$reminderField, $attendeesFields);
 
         // skip if none of the required fields was modified
-        if (! $this->isRequiredModified($entity, $requiredFields)) {
+        if (! $this->isRequiredModified($entity, $requiredFields, $table)) {
             return [];
         }
 
@@ -271,14 +272,24 @@ class ModelAfterSaveListener implements EventListenerInterface
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity instance
      * @param string[] $requiredFields Required fields list
+     * @param \Cake\ORM\Table $table Table instance
      * @return bool
      */
-    protected function isRequiredModified(EntityInterface $entity, array $requiredFields) : bool
+    protected function isRequiredModified(EntityInterface $entity, array $requiredFields, Table $table) : bool
     {
         foreach ($requiredFields as $field) {
-            if ($entity->isDirty($field)) {
-                return true;
+            if (! $entity->isDirty($field)) {
+                continue;
             }
+            $columnType = $table->getSchema()->getColumnType($field);
+            $toPHP = Type::build($columnType)->toPHP($entity->get($field), $table->getConnection()->getDriver());
+
+            // loose comparison on purpose
+            if ($toPHP == $entity->getOriginal($field)) {
+                continue;
+            }
+
+            return true;
         }
 
         return false;

--- a/src/Utility/ICal/IcEmail.php
+++ b/src/Utility/ICal/IcEmail.php
@@ -325,6 +325,10 @@ class IcEmail
             }
 
             $columnType = $this->table->getSchema()->getColumnType($modifiedField);
+            if (null === $columnType) {
+                continue;
+            }
+
             $toPHP = Type::build($columnType)->toPHP(
                 $this->entity->get($modifiedField),
                 $this->table->getConnection()->getDriver()

--- a/src/Utility/ICal/IcEmail.php
+++ b/src/Utility/ICal/IcEmail.php
@@ -247,12 +247,15 @@ class IcEmail
      */
     public function getEntityUrl() : string
     {
+        $primaryKey = $this->table->getPrimaryKey();
+        Assert::string($primaryKey);
+
         $result = Router::url(
             [
                 'prefix' => false,
                 'controller' => $this->table->getTable(),
                 'action' => 'view',
-                $this->entity->id
+                $this->entity->get($primaryKey)
             ],
             true
         );

--- a/tests/TestCase/Utility/ICal/IcEmailTest.php
+++ b/tests/TestCase/Utility/ICal/IcEmailTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace CsvMigrations\Test\TestCase\Utility\ICal;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use CsvMigrations\Utility\ICal\IcEmail;
+
+class IcEmailTest extends TestCase
+{
+    public $fixtures = ['plugin.CsvMigrations.articles'];
+
+    private $table;
+    private $entity;
+
+    public function setUp() : void
+    {
+        $this->table = TableRegistry::getTableLocator()->get('Articles');
+        $this->entity = $this->table->newEntity(['name' => 'Hello World!', 'status' => 'draft']);
+        $this->table->saveOrFail($this->entity);
+        $this->table->patchEntity($this->entity, ['status' => 'published']);
+    }
+
+    public function testGetEmailSubject() : void
+    {
+        $this->assertSame(
+            '(Updated) Article: Hello World!',
+            (new IcEmail($this->table, $this->entity))->getEmailSubject()
+        );
+    }
+
+    public function testGetEmailSubjectWithNewEntity() : void
+    {
+        $this->assertSame(
+            'Article: Foobar',
+            (new IcEmail($this->table, $this->table->newEntity(['name' => 'Foobar'])))->getEmailSubject()
+        );
+    }
+
+    public function testGetEventSubject() : void
+    {
+        $icEmail = new IcEmail($this->table, $this->entity);
+
+        $this->assertSame(
+            $icEmail->getEmailSubject(),
+            $icEmail->getEventSubject()
+        );
+    }
+
+    public function testGetEventSubjectWithNewEntity() : void
+    {
+        $icEmail = new IcEmail($this->table, $this->table->newEntity(['name' => 'Foobar']));
+
+        $this->assertSame(
+            $icEmail->getEmailSubject(),
+            $icEmail->getEventSubject()
+        );
+    }
+
+    public function testGetEntityUrl() : void
+    {
+        $this->assertSame(
+            '/articles/view/' . $this->entity->get('id'),
+            (new IcEmail($this->table, $this->entity))->getEntityUrl()
+        );
+    }
+
+    public function testGetEntityUrlWithNewEntity() : void
+    {
+        $this->assertSame(
+            '/articles/view',
+            (new IcEmail($this->table, $this->table->newEntity(['name' => 'Foobar'])))->getEntityUrl()
+        );
+    }
+
+    public function testGetEmailContent() : void
+    {
+        $this->assertSame(
+            "Article \"Hello World!\" updated by System\n\n* Status: changed from \"draft\" to \"published\".\n\n\n\nSee more: /articles/view/" . $this->entity->get('id'),
+            (new IcEmail($this->table, $this->entity))->getEmailContent()
+        );
+    }
+
+    public function testGetEmailContentWithNewEntity() : void
+    {
+        $this->assertSame(
+            "Article \"Foobar\" created by System\n\nSee more: /articles/view",
+            (new IcEmail($this->table, $this->table->newEntity(['name' => 'Foobar'])))->getEmailContent()
+        );
+    }
+
+    public function testGetEventContent() : void
+    {
+        $this->assertSame(
+            "\n\nSee more: /articles/view/" . $this->entity->get('id'),
+            (new IcEmail($this->table, $this->entity))->getEventContent()
+        );
+    }
+
+    public function testSendCalendarEmail() : void
+    {
+        $icEmail = new IcEmail($this->table, $this->entity);
+        $subject = $icEmail->getEmailSubject();
+        $content = $icEmail->getEmailContent();
+        $sent = $icEmail->sendCalendarEmail('foo@bar.com', $subject, $content, []);
+
+        $pattern = '/Content-Disposition: attachment; filename="event.ics"\\r\\nContent-Type: text\/calendar\\r\\nContent-Transfer-Encoding: base64\\r/';
+
+        $this->assertRegExp($pattern, $sent['message']);
+    }
+}

--- a/tests/TestCase/Utility/ICal/IcEmailTest.php
+++ b/tests/TestCase/Utility/ICal/IcEmailTest.php
@@ -20,6 +20,12 @@ class IcEmailTest extends TestCase
         $this->table->patchEntity($this->entity, ['status' => 'published']);
     }
 
+    public function tearDown() : void
+    {
+        unset($this->entity);
+        unset($this->table);
+    }
+
     public function testGetEmailSubject() : void
     {
         $this->assertSame(


### PR DESCRIPTION
- Added Unit tests for `IcEmail` class.
- Use `RelatedPlainRenderer` to avoid HTML tag stripping, trimming etc.
- Use `CsvField` class for retrieving field type to avoid additional regular-expression and to get rid of `fieldDefinitions()` method dependency.
- Convert the new column value into PHP format for more accurate comparison with the original one.
- Switched to PHP format on new values for more accurate comparison during changelog generation.
- Removed hardcoding of the primary key name.
- Git ignored _tmp_ directory.