### PR TITLE
Report unused fields as warnings (task #13464)

### DIFF
--- a/tests/TestCase/Utility/Validate/Check/MigrationCheckTest.php
+++ b/tests/TestCase/Utility/Validate/Check/MigrationCheckTest.php
@@ -62,4 +62,11 @@ class MigrationCheckTest extends TestCase
         $result = $this->check->getErrors();
         $this->assertTrue(is_array($result), "getErrors() returned a non-array result");
     }
+
+    public function testGetUnusedFields() : void
+    {
+        $result = $this->check->run('Foo');
+        $result = $this->check->getWarnings();
+        $this->assertTrue(in_array('Foo field \'reminder_date\' is not being used in any view', $result));
+    }
 }


### PR DESCRIPTION
Fields that are not being used in any views are reported as warnings during the module validation. They are being reported as warnings (and not errors) since it's completely fine to have such fields as the `id`. 