### PR TITLE
Adjust placeholder syntax (task #13532)

### DIFF
--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -200,9 +200,16 @@ trait RelatedFieldTrait
             $result = array_merge($result, $fields);
         }
 
-        return implode(', or ', array_map(function ($value) {
-            return Inflector::humanize($value);
+        if (2 > count($result)) {
+            return Inflector::humanize(implode('', $result));
+        }
+
+        $last = array_pop($result);
+        $first = implode(', ', array_map(function ($item) {
+            return Inflector::humanize($item);
         }, $result));
+
+        return sprintf('%s or %s', $first, Inflector::humanize($last));
     }
 
     /**

--- a/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
+++ b/tests/TestCase/FieldHandlers/RelatedFieldHandlerTest.php
@@ -60,7 +60,7 @@ class RelatedFieldHandlerTest extends TestCase
         $this->assertContains('data-url="/api/foo/lookup.json"', $result);
 
         // test helper text
-        $this->assertContains('title="Id, or Created, or Gender"', $result);
+        $this->assertContains('title="Id, Created or Gender"', $result);
 
         // test icon
         $this->assertContains('<span class="fa fa-user"></span>', $result);


### PR DESCRIPTION
This PR adjusts the syntax of the _related_ type inputs from `Field A, or Field B, or Field C` to `Field A, Field B or Field C`.