### PR TITLE
Removing log notice in case reminder field doesnt exist

### DIFF
--- a/src/Event/Model/ModelAfterSaveListener.php
+++ b/src/Event/Model/ModelAfterSaveListener.php
@@ -107,8 +107,6 @@ class ModelAfterSaveListener implements EventListenerInterface
         // figure out which field is a reminder one (example: start_date)
         $reminderField = $this->getReminderField($table);
         if ('' === $reminderField) {
-            $this->log('Failed to find reminder fields', LogLevel::NOTICE);
-
             return [];
         }
 


### PR DESCRIPTION
Not all the modules in the system might have "reminder" field types, thus, we can easily remove this log notice. 
Besides that, in case of the event is not properly added for notifications (via email/calendar), other errors will be populated