### PR TITLE
Updated module bake templates

### DIFF
--- a/src/Template/Bake/Controller/controller.twig
+++ b/src/Template/Bake/Controller/controller.twig
@@ -15,6 +15,6 @@ namespace App\Controller;
 
 use CsvMigrations\Controller\AppController as BaseController;
 
-class {{ name }}Controller extends BaseController
+class {{ name }}Controller extends BaseModuleController
 {
 }

--- a/src/Template/Bake/Module/config/config.twig
+++ b/src/Template/Bake/Module/config/config.twig
@@ -1,9 +1,13 @@
 {
     "table": {
+        "type": "module",
         "icon": "cube",
+        "display_field": "id",
         "searchable": true
     },
     "notifications": {
-        "enable": true
-    }
+        "enable": true,
+        "ignored_fields": []
+    },
+    "virtualFields": {}
 }

--- a/src/Template/Bake/Module/views/index.twig
+++ b/src/Template/Bake/Module/views/index.twig
@@ -1,6 +1,9 @@
 {
     "items": [
         [
+            "id"
+        ],
+        [
             "created"
         ],
         [

--- a/src/Template/Bake/Module/views/view.twig
+++ b/src/Template/Bake/Module/views/view.twig
@@ -1,9 +1,11 @@
 {
     "items": [
         [
-            "Details",
+            "Meta Details",
+            "modified",
+            "modified_by",
             "created",
-            "modified"
+            "created_by"
         ]
     ]
 }


### PR DESCRIPTION
Updated module bake templates so that newly baked modules can
both pass the validation and work correctly.

Here are some of the fixed issues:

* Module's controller template now uses BaseModuleController as
  parent class.  This fixes the related tabs on modules with
  many-to-many relationships.
* Module's config.json template now includes `type=module`.  This
  is necessary for baking CSV relations, as the shell uses this
  for the selection of the available modules.
* Module's config.json template now includes `display_field=id`.
  Display field is a required property of the config file and
  without it, the validation fails.  Assuming 'id' field exists
  in pretty much every module.
* Module's config.json now includes `notifications.ignored_fields=[]`.
  Again, this is a required property, the absence of which breaks
  the validation.
* Module's config.json now includes `virtualFields={}`.  Also a
  required property.
* Module's index view now includes the `id field.  The default
  index view is very confusing with only created and modified dates.
* Module's view view now includes both `modified_by` and `created_by`
  meta fields.  These were are as useful as `created` and `modified`
  which were already there.  It's easier to remove them for those
  modules that don't need them, than to add to those that do.