### PR TITLE
Update bake templates

### DIFF
--- a/src/Shell/Task/CsvRelationTask.php
+++ b/src/Shell/Task/CsvRelationTask.php
@@ -217,9 +217,9 @@ class CsvRelationTask extends BakeTask
             $fields[$this->_modelKey($module)] = [
                 'name' => $this->_modelKey($module),
                 'type' => sprintf('related(%s)', $module),
-                'required' => '1',
-                'non-searchable' => null,
-                'unique' => null
+                'required' => true,
+                'non-searchable' => false,
+                'unique' => false
             ];
         }
 

--- a/src/Shell/Task/CsvRelationTask.php
+++ b/src/Shell/Task/CsvRelationTask.php
@@ -212,7 +212,30 @@ class CsvRelationTask extends BakeTask
      */
     private function bakeDatabaseConfig(array $selection, string $path) : bool
     {
-        $fields = [];
+        $fields = [
+            'id' => [
+                'name' => 'id',
+                'type' => 'uuid',
+                'required' => true,
+                'non-searchable' => false,
+                'unique' => true
+            ],
+            'created' => [
+                'name' => 'created',
+                'type' => 'datetime',
+                'required' => false,
+                'non-searchable' => false,
+                'unique' => false
+            ],
+            'modified' => [
+                'name' => 'modified',
+                'type' => 'datetime',
+                'required' => false,
+                'non-searchable' => false,
+                'unique' => false
+            ],
+        ];
+
         foreach ($selection as $module) {
             $fields[$this->_modelKey($module)] = [
                 'name' => $this->_modelKey($module),


### PR DESCRIPTION
This PR fixes two issues with the baked migrations for relations:

1. Outdated values (null, "1") used for boolean fields.
2. Missing required fields (id, created, modified).