### PR TITLE
Auto increment bugfix (task #14749)

### DIFF
--- a/src/Event/Model/AutoIncrementEventListener.php
+++ b/src/Event/Model/AutoIncrementEventListener.php
@@ -69,7 +69,9 @@ class AutoIncrementEventListener implements EventListenerInterface
         if (! $entity->isNew()) {
             foreach (array_keys($fields) as $field) {
                 Assert::isInstanceOf($entity, Entity::class);
-                $entity->set((string)$field, $entity->getOriginal((string)$field));
+                if ($entity->has((string)$field)) {
+                    $entity->set((string)$field, $entity->getOriginal((string)$field));
+                }
             }
 
             return;

--- a/tests/Fixture/FooFixture.php
+++ b/tests/Fixture/FooFixture.php
@@ -8,9 +8,6 @@ class FooFixture extends TestFixture
 {
     public $table = 'foo';
 
-    // Optional. Set this property to load fixtures to a different test datasource
-    public $connection = 'test';
-
     public $fields = [
         'id' => ['type' => 'uuid'],
         'description' => ['type' => 'text', 'null' => true],
@@ -34,6 +31,7 @@ class FooFixture extends TestFixture
         'modified_by' => ['type' => 'uuid', 'null' => true],
         'is_primary' => ['type' => 'boolean', 'null' => true],
         'trashed' => ['type' => 'datetime', 'null' => true],
+        'reference' => ['type' => 'integer', 'null' => true],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
             'unique' => ['type' => 'unique', 'columns' => ['name', 'id']]

--- a/tests/TestCase/Event/Model/AutoIncrementEventListenerTest.php
+++ b/tests/TestCase/Event/Model/AutoIncrementEventListenerTest.php
@@ -70,4 +70,20 @@ class AutoIncrementEventListenerTest extends TestCase
         $this->table->saveOrFail($existingEntity);
         $this->assertSame(10, $existingEntity->get($this->autoincrementField));
     }
+
+    public function testAutoIncrementWithExistingPartialEntity(): void
+    {
+        $newEntity = $this->table->newEntity($this->data);
+        $this->table->saveOrFail($newEntity);
+
+        $this->assertSame(10, $newEntity->get($this->autoincrementField));
+
+
+        $existingEntity = $this->table->get($newEntity->get('id'), ['fields' => ['id', 'name']]);
+        $this->table->patchEntity($existingEntity, ['status' => 'inactive']);
+        $this->table->saveOrFail($existingEntity);
+
+        $existingEntity = $this->table->get($existingEntity->get('id'));
+        $this->assertSame(10, $existingEntity->get($this->autoincrementField));
+    }
 }

--- a/tests/TestCase/Event/Model/AutoIncrementEventListenerTest.php
+++ b/tests/TestCase/Event/Model/AutoIncrementEventListenerTest.php
@@ -23,7 +23,7 @@ class AutoIncrementEventListenerTest extends TestCase
     public $fixtures = ['plugin.CsvMigrations.Foo'];
 
     private $table;
-    private $autoincrementField ='reference';
+    private $autoincrementField = 'reference';
     private $data = ['name' => 'auto-increment test', 'status' => 'active', 'type' => 'bronze.used'];
 
     public function setUp(): void
@@ -64,7 +64,6 @@ class AutoIncrementEventListenerTest extends TestCase
 
         $this->assertSame(10, $newEntity->get($this->autoincrementField));
 
-
         $existingEntity = $this->table->get($newEntity->get('id'));
         $this->table->patchEntity($existingEntity, ['status' => 'inactive']);
         $this->table->saveOrFail($existingEntity);
@@ -77,7 +76,6 @@ class AutoIncrementEventListenerTest extends TestCase
         $this->table->saveOrFail($newEntity);
 
         $this->assertSame(10, $newEntity->get($this->autoincrementField));
-
 
         $existingEntity = $this->table->get($newEntity->get('id'), ['fields' => ['id', 'name']]);
         $this->table->patchEntity($existingEntity, ['status' => 'inactive']);

--- a/tests/TestCase/Event/Model/AutoIncrementEventListenerTest.php
+++ b/tests/TestCase/Event/Model/AutoIncrementEventListenerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace CsvMigrations\Test\TestCase\Event\Model;
+
+use Cake\Event\EventManager;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use CsvMigrations\Event\Model\AutoIncrementEventListener;
+
+class AutoIncrementEventListenerTest extends TestCase
+{
+    public $fixtures = ['plugin.CsvMigrations.Foo'];
+
+    private $table;
+    private $autoincrementField ='reference';
+    private $data = ['name' => 'auto-increment test', 'status' => 'active', 'type' => 'bronze.used'];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->table = TableRegistry::getTableLocator()->get('Foo');
+
+        EventManager::instance()->on(new AutoIncrementEventListener());
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->data);
+        unset($this->autoincrementField);
+        unset($this->table);
+
+        parent::tearDown();
+    }
+
+    public function testAutoIncrementWithNewEntities(): void
+    {
+        $firstEntity = $this->table->newEntity($this->data);
+
+        $this->table->saveOrFail($firstEntity);
+        $this->assertSame(10, $firstEntity->get($this->autoincrementField));
+
+        $secondEntity = $this->table->newEntity($this->data);
+        $this->table->saveOrFail($secondEntity);
+
+        $this->assertSame(11.0, $secondEntity->get($this->autoincrementField));
+    }
+
+    public function testAutoIncrementWithExistingEntity(): void
+    {
+        $newEntity = $this->table->newEntity($this->data);
+        $this->table->saveOrFail($newEntity);
+
+        $this->assertSame(10, $newEntity->get($this->autoincrementField));
+
+
+        $existingEntity = $this->table->get($newEntity->get('id'));
+        $this->table->patchEntity($existingEntity, ['status' => 'inactive']);
+        $this->table->saveOrFail($existingEntity);
+        $this->assertSame(10, $existingEntity->get($this->autoincrementField));
+    }
+}

--- a/tests/TestCase/Model/Table/FooTableTest.php
+++ b/tests/TestCase/Model/Table/FooTableTest.php
@@ -149,6 +149,7 @@ class FooTableTest extends TestCase
                     'start_time' => ['name' => 'start_time', 'type' => 'time', 'required' => '', 'non-searchable' => '', 'unique' => false],
                     'balance' => ['name' => 'balance', 'type' => 'decimal(12.4)', 'required' => '', 'non-searchable' => '', 'unique' => false],
                     'lead' => ['name' => 'lead', 'type' => 'related(Leads)', 'required' => '', 'non-searchable' => '', 'unique' => false],
+                    'reference' => ['name' => 'reference', 'type' => 'integer', 'required' => '', 'non-searchable' => '', 'unique' => false],
                     'created_by' => ['name' => 'created_by', 'type' => 'related(Users)', 'required' => '', 'non-searchable' => '', 'unique' => false],
                     'modified_by' => ['name' => 'modified_by', 'type' => 'related(Users)', 'required' => '', 'non-searchable' => '', 'unique' => false]
                 ]

--- a/tests/config/Modules/Foo/config/fields.json
+++ b/tests/config/Modules/Foo/config/fields.json
@@ -1,5 +1,9 @@
 {
     "status": {
         "renderAs": "plain"
+    },
+    "reference": {
+        "auto-increment": true,
+        "min": 10
     }
 }

--- a/tests/config/Modules/Foo/db/migration.json
+++ b/tests/config/Modules/Foo/db/migration.json
@@ -125,6 +125,13 @@
         "non-searchable": false,
         "unique": false
     },
+    "reference": {
+        "name": "reference",
+        "type": "integer",
+        "required": false,
+        "non-searchable": false,
+        "unique": false
+    },
     "created_by": {
         "name": "created_by",
         "type": "related(Users)",


### PR DESCRIPTION
This PR resolves a bug in our auto-increment logic, where if we are persisting an existing entity that does not have the auto-increment field/property set in the instance, the value of the auto-increment column is set to `NULL`.