### PR TITLE
Coordinates modal improvements (task #15152)

### DIFF
--- a/src/Template/Element/FieldHandlers/CoordinatesFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/CoordinatesFieldHandler/input.ctp
@@ -70,7 +70,7 @@ echo $this->Form->control($name, $attributes);
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <button type="button" class="close" data-dismiss="coordinates-modal" aria-label="Close">
           <span aria-hidden="true">&times;</span></button>
             <h4 class="modal-title"><?= __($label); ?></h4>
             <div><i class="fa fa-map-marker"></i> <span class="modal_gps_value"><?= $value; ?></span></div>
@@ -79,8 +79,8 @@ echo $this->Form->control($name, $attributes);
 
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default pull-left" data-dismiss="modal"><?= __('Cancel') ?></button>
-        <button type="button" class="btn btn-primary save_gps" data-dismiss="modal"><?= __('Apply') ?></button>
+        <button type="button" class="btn btn-default pull-left" data-dismiss="coordinates-modal"><?= __('Cancel') ?></button>
+        <button type="button" class="btn btn-primary save_gps" data-dismiss="coordinates-modal"><?= __('Apply') ?></button>
       </div>
     </div>
   </div>

--- a/webroot/js/coordinatespicker.editinit.js
+++ b/webroot/js/coordinatespicker.editinit.js
@@ -1,7 +1,9 @@
 $(document).ready(function () {
     $('.coordinates_modal').each(function (event) {
         let gps_input = $(this).prev().find('input')
-        let gps_value = $(gps_input).attr("value").length > 0 ? $(gps_input).attr("value") : $(gps_input).attr("default_coordinates")
+        let gps_value = $(gps_input).attr("value") && $(gps_input).attr("value").length > 0 ?
+            $(gps_input).attr("value") :
+            $(gps_input).attr("default_coordinates")
         $(this).on('shown.bs.modal', function () {
             $(this).find(".modal-body").append('<div style="height:300px" id="map"></div>')
             drawMap("map", gps_value)

--- a/webroot/js/coordinatespicker.editinit.js
+++ b/webroot/js/coordinatespicker.editinit.js
@@ -16,4 +16,8 @@ $(document).ready(function () {
             $(gps_input).val(coordinates)
         })
     })
+
+    $("button[data-dismiss='coordinates-modal']").click(function () {
+        $(this).closest('.modal').modal('hide')
+    })
 })


### PR DESCRIPTION
This PR fixes the following issues:
- Check value length only if a value is defined
- Dismiss only coordinates modal, ignoring any other DOM modals