### PR TITLE
Improve parsing list name during import (Task #15192)

### DIFF
--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -562,7 +562,11 @@ class ImportShell extends Shell
      */
     protected function _findListValue(RepositoryInterface $table, string $listName, string $value): string
     {
-        $options = FieldUtility::getList(sprintf('%s.%s', $table->getAlias(), $listName), true);
+        if (false !== strpos($listName, '.')) {
+            $options = FieldUtility::getList($listName, true);
+        } else {
+            $options = FieldUtility::getList(sprintf('%s.%s', $table->getAlias(), $listName), true);
+        }
 
         // check against list options values
         foreach ($options as $val => $params) {


### PR DESCRIPTION
This PR fixes  an issue that the list type value fail to be parse during import as it prefixes the list name from list(Module.listname) as Module.Module.listname in the case the list name is already prefix with module

