### PR TITLE
Input forms improvement (task #15376)

### DIFF
--- a/src/Template/Element/FieldHandlers/BelongsToManyFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/BelongsToManyFieldHandler/input.ctp
@@ -16,7 +16,7 @@ $attributes = isset($attributes) ? $attributes : [];
 
 $attributes += [
     'label' => false,
-    'id' => $association->className(),
+    'id' => $association->getName(),
     'type' => $type,
     'options' => $options,
     'value' => $value,

--- a/src/Template/Element/FieldHandlers/BelongsToManyFieldHandler/view.ctp
+++ b/src/Template/Element/FieldHandlers/BelongsToManyFieldHandler/view.ctp
@@ -2,9 +2,9 @@
 
 use Cake\Core\Configure;
 ?>
-<ul class="list-unstyled">
+<ul class="list-inline">
     <?php foreach ($associationList as $id => $title) { ?>
-        <li style="padding-bottom: 2px;">
+        <li>
             <?php
             if (isset($options['renderAs']) && $options['renderAs'] === 'plain') {
                 echo $title;

--- a/webroot/js/embedded.js
+++ b/webroot/js/embedded.js
@@ -49,7 +49,6 @@ var embedded = embedded || {};
      */
     Embedded.prototype._submitForm = function (form) {
         var that = this;
-        var withRelate = $(form).data('embedded-related-model') && $(form).data('embedded-related-id');
 
         $.ajax({
             url: $(form).attr('action'),
@@ -62,7 +61,7 @@ var embedded = embedded || {};
             },
             success: function (data, textStatus, jqXHR) {
                 // set related field display-field and value
-                withRelate ? that._setRelations(data.data.id, form) : that._setRelatedField(data.data.id, form);
+                that._setRelatedField(data.data.id, form);
 
                 // reset embedded form
                 $(form)[0].reset();
@@ -129,8 +128,8 @@ var embedded = embedded || {};
             headers: {
                 'Authorization': 'Bearer ' + that.api_token
             },
-            success: function (data, textStatus, jqXHR) {
-                location.reload();
+            success: function (response, textStatus, jqXHR) {
+                that._setRelatedField(id, form)
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR);


### PR DESCRIPTION
This PR fixes the issue where the page is reloaded when creating a related `M:M` record.

The fix resolves form input data loss on forms where a definition of `ASSOCIATION(field_name)` is used.