### PR TITLE
Avoid empty value on multiple list (task #15774)

### DIFF
--- a/src/FieldHandlers/Provider/RenderInput/ListRenderer.php
+++ b/src/FieldHandlers/Provider/RenderInput/ListRenderer.php
@@ -35,7 +35,7 @@ class ListRenderer extends AbstractRenderer
         $field = $this->config->getField();
         $table = $this->config->getTable();
         $fieldName = $table->aliasField($field);
-        $selectOptions = ['' => Setting::EMPTY_OPTION_LABEL()];
+        $selectOptions = empty($options['attributes']['multiple']) ? ['' => Setting::EMPTY_OPTION_LABEL()] : [];
 
         // if select options are not pre-defined
         if (empty($options['selectOptions'])) {


### PR DESCRIPTION
We can easily render multiple select with the type list adding `'attributes' => [ 'multiple' => true,]`, but in the cakephp-csv-migrations/src/FieldHandlers/Provider/RenderInput/ListRenderer.php we hard code the first selectOption. This causes few problems as screenshots shows.
![image](https://user-images.githubusercontent.com/40852083/77298482-ab98ec00-6cf3-11ea-85d1-bfa04aed393c.png)
![image](https://user-images.githubusercontent.com/40852083/77298504-b18ecd00-6cf3-11ea-9382-b9cd2b91e187.png)
