### PR TITLE
Adding a getter to Field Factory (Task #16095)

### DIFF
--- a/src/FieldHandlers/FieldHandler.php
+++ b/src/FieldHandlers/FieldHandler.php
@@ -188,6 +188,16 @@ class FieldHandler implements FieldHandlerInterface
     }
 
     /**
+     * Get Default Value of the Field Handler
+     *
+     * @return mixed
+     */
+    public function getDefaultValue()
+    {
+        return $this->defaultOptions['default'];
+    }
+
+    /**
      * Fix provided options
      *
      * This method is here to fix some issues with backward

--- a/src/FieldHandlers/FieldHandlerFactory.php
+++ b/src/FieldHandlers/FieldHandlerFactory.php
@@ -121,6 +121,21 @@ class FieldHandlerFactory
     }
 
     /**
+     * Get Default Render Value from Renderers
+     *
+     * @param mixed $table Name or instance of the Table
+     * @param string $field Field name
+     * @param mixed[] $options Field options
+     * @return mixed
+     */
+    public function getDefaultValue($table, string $field, array $options = [])
+    {
+        $handler = self::getByTableField($table, $field, $options, $this->cakeView);
+
+        return $handler->getDefaultValue();
+    }
+
+    /**
      * Validation rules setter.
      *
      * @param mixed $table Name or instance of the Table

--- a/src/FieldHandlers/FieldHandlerInterface.php
+++ b/src/FieldHandlers/FieldHandlerInterface.php
@@ -114,4 +114,11 @@ interface FieldHandlerInterface
      * @return \Cake\Validation\Validator
      */
     public function setValidationRules(Validator $validator, array $options = []): Validator;
+
+    /**
+     * Get Default Value of the Field Handler
+     *
+     * @return mixed
+     */
+    public function getDefaultValue();
 }


### PR DESCRIPTION
A very simple getter that allows us to get the default value that will be used for `renderInput()` call.