### PR TITLE
Allow better transition from md to xs for dropdowns (task #16478)

### DIFF
--- a/src/Template/Element/FieldHandlers/CombinedFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/CombinedFieldHandler/input.ctp
@@ -23,7 +23,7 @@ foreach (array_keys($inputs) as $fieldName) {
     <?= $this->Html->help($help); ?>
     <div class="row combined-field">
     <?php foreach ($inputs as $input) : ?>
-        <div class="col-xs-6 col-lg-4"><?= $input ?></div>
+        <div class="col-xs-6 col-md-6 col-lg-5"><?= $input ?></div>
     <?php endforeach; ?>
     </div>
 </div>


### PR DESCRIPTION
By increasing the width of Bootstap cells we get better transition from `lg` to `md` to `xs` classes when the display resolution changes.