### PR TITLE
Pick parents for redirects (task #16553)

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -210,34 +210,46 @@ class Table extends BaseTable implements HasFieldsInterface
      *
      * @param \Cake\ORM\Table $table of the entity table
      * @param \Cake\Datasource\EntityInterface $entity of the actual table.
+     * @param string $parent identifying which config to pick
      *
      * @return mixed[] $result containing CakePHP-standard array for redirect.
      */
-    public function getParentRedirectUrl(RepositoryInterface $table, EntityInterface $entity): array
+    public function getParentRedirectUrl(RepositoryInterface $table, EntityInterface $entity, string $parent): array
     {
         $config = ModuleRegistry::getModule($this->getAlias())->getConfig();
-
-        if (empty($config['parent']['redirect'])) {
+        if (empty($config['parent'])) {
             return [];
         }
 
-        if ('parent' === $config['parent']['redirect']) {
-            if (! isset($config['parent']['module'])) {
+        $parentConfig = [];
+
+        foreach ($config['parent'] as $item) {
+            if ($item['module'] === $parent) {
+                $parentConfig = $item;
+            }
+        }
+
+        if (empty($parentConfig)) {
+            return [];
+        }
+
+        if ('parent' === $parentConfig['redirect']) {
+            if (! isset($parentConfig['module'])) {
                 return [];
             }
 
-            if (! isset($config['parent']['relation'])) {
+            if (! isset($parentConfig['relation'])) {
                 return [];
             }
 
             return [
-                'controller' => $config['parent']['module'],
-                'action' => $entity->get($config['parent']['relation']) ? 'view' : 'index',
-                $entity->get($config['parent']['relation']),
+                'controller' => $parentConfig['module'],
+                'action' => $entity->get($parentConfig['relation']) ? 'view' : 'index',
+                $entity->get($parentConfig['relation']),
             ];
         }
 
-        if ('self' === $config['parent']['redirect']) {
+        if ('self' === $parentConfig['redirect']) {
             $values = [];
             foreach ((array)$table->getPrimaryKey() as $primaryKey) {
                 $values[] = $entity->get($primaryKey);

--- a/tests/TestCase/Model/Table/FooTableTest.php
+++ b/tests/TestCase/Model/Table/FooTableTest.php
@@ -99,7 +99,7 @@ class FooTableTest extends TestCase
 
     public function testGetParentRedirectUrl(): void
     {
-        $result = $this->table->getParentRedirectUrl($this->table, $this->table->find()->firstOrFail());
+        $result = $this->table->getParentRedirectUrl($this->table, $this->table->find()->firstOrFail(), 'Leads');
         $this->assertTrue(is_array($result));
     }
 

--- a/tests/config/Modules/Foo/config/config.json
+++ b/tests/config/Modules/Foo/config/config.json
@@ -36,11 +36,13 @@
             "Users"
         ]
     },
-    "parent": {
-        "module": "Leads",
-        "relation": "lead",
-        "redirect": "parent"
-    },
+    "parent": [
+        {
+            "module": "Leads",
+            "relation": "lead",
+            "redirect": "parent"
+        }
+    ],
     "associations": {
         "hide_associations": [
             "TestTable",


### PR DESCRIPTION
We slightly rework the notion of redirects in what's been done years ago. 

Having only one parent for the table that contains more than one foreign_key is impractical. 
We allow specifying multiple parents to ensure that we can have proper parent redirects based on the config https://github.com/QoboLtd/cakephp-utils/pull/222.

Note: it should be merged after `cakephp-utils` PR is merged & tagged.

