### PR TITLE
Disable dynamic panel in batch edit (task #16689)

### DIFF
--- a/webroot/js/panels.js
+++ b/webroot/js/panels.js
@@ -78,7 +78,9 @@
     };
 
     Panel.prototype.resetPanels = function () {
-        $(this.form).find('[data-provide="dynamic-panel"].hidden').find(':input').attr('disabled', false);
+        if (window.location.href.indexOf("/batch/edit") === -1) {
+            $(this.form).find('[data-provide="dynamic-panel"].hidden').find(':input').attr('disabled', false);
+        }
         $(this.form).find('[data-provide="dynamic-panel"]').removeClass('hidden');
     };
 


### PR DESCRIPTION
The dynamic panel in the batch edit has all the field enabled when appear the form.
This will reset all the information hold in this panel for each entity selected in the batch.