### PR TITLE
Avoid render NULL values (task #16657)

### DIFF
--- a/src/FieldHandlers/Provider/RenderValue/NumberRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/NumberRenderer.php
@@ -48,6 +48,11 @@ class NumberRenderer extends AbstractRenderer
             return '0';
         }
 
+        // Avoid to render NULL data
+        if (is_null($data)) {
+            return '';
+        }
+
         // Sanitize
         $number = filter_var($data, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
 


### PR DESCRIPTION
It seems that when a decimal is null, we display 0 instead.
This happens mainly for decimal values and in views (not in forms)