### PR TITLE
Return if parent module is disabled (task #16735)

### DIFF
--- a/src/FieldHandlers/RelatedFieldTrait.php
+++ b/src/FieldHandlers/RelatedFieldTrait.php
@@ -51,6 +51,12 @@ trait RelatedFieldTrait
         }
         // @codingStandardsIgnoreEnd
 
+        // Return if the module is disable
+        $table = TableRegistry::get($relatedProperties['config']['parent']['module']);
+        if (empty($table)) {
+            return [];
+        }
+
         $foreignKey = $this->_getForeignKey(
             TableRegistry::get($relatedProperties['config']['parent']['module']),
             empty($relatedProperties['plugin']) ?


### PR DESCRIPTION
If in the config.json we have

```
    "parent": [{
        "module": "<moduleName>"
    }],
```
but the module is disable, an error happend.

> Cake\Error\PHP7ErrorException: (TypeError) - Argument 1 passed to CsvMigrations\FieldHandlers\Provider\RenderInput\RelatedRenderer::_getForeignKey() must be an instance of Cake\ORM\Table, null given, called in /vendor/qobo/cakephp-csv-migrations/src/FieldHandlers/RelatedFieldTrait.php on line 58 in /vendor/qobo/cakephp-csv-migrations/src/FieldHandlers/RelatedFieldTrait.php on 134
