### PR TITLE
Use module name instead of table name (Task #16964)

### DIFF
--- a/src/Template/Element/FieldHandlers/FilesFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/FilesFieldHandler/input.ctp
@@ -17,7 +17,7 @@ $attributes = isset($attributes) ? $attributes : [];
 
 $class = str_replace('.', '_', $name . '_ids');
 
-$config = ModuleRegistry::getModule($table)->getFields();
+$config = ModuleRegistry::getModule($this->name)->getFields();
 
 $options = [
     'multiple' => true,


### PR DESCRIPTION
This PR fixes an issue were add/edit forms couldn't be loaded in case file fields exist in the form