### PR TITLE
adding badge functionality for related fh (task #17027)

### DIFF
--- a/src/FieldHandlers/Provider/RenderValue/BadgeRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/BadgeRenderer.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CsvMigrations\FieldHandlers\Provider\RenderValue;
+
+/**
+ * BadgeRenderer
+ *
+ * Allow us keep the badge functionality of Related fields, without
+ * disclosing the URL.
+ *
+ */
+class BadgeRenderer extends RelatedRenderer
+{
+    /**
+     * Provide rendered value
+     *
+     * @param mixed $data Data to use for provision
+     * @param array $options Options to use for provision
+     * @return mixed
+     */
+    public function provide($data = null, array $options = [])
+    {
+        return parent::provide($data, $options);
+    }
+}

--- a/src/FieldHandlers/Provider/RenderValue/BadgeRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/BadgeRenderer.php
@@ -16,7 +16,6 @@ namespace CsvMigrations\FieldHandlers\Provider\RenderValue;
  *
  * Allow us keep the badge functionality of Related fields, without
  * disclosing the URL.
- *
  */
 class BadgeRenderer extends RelatedRenderer
 {

--- a/src/Template/Element/FieldHandlers/RelatedFieldHandler/view.ctp
+++ b/src/Template/Element/FieldHandlers/RelatedFieldHandler/view.ctp
@@ -7,19 +7,23 @@ foreach ($relatedProperties as $properties) {
         continue;
     }
 
+    // generate related record(s) html link
+    $title = $properties['dispFieldVal'];
+
+    // Special case for entities having an image_src like Users
+    if (Configure::read('Theme.prependAvatars', true) && !empty($properties['entity']['image_src'])) {
+        $title = '<img alt="Thumbnail" src="' . $properties['entity']['image_src'] . '" style="width: 20px; height: 20px;" class="img-circle">&nbsp;&nbsp;' . $title;
+    } elseif (!empty($properties['config']['table']['icon'])) {
+        $title = '<i class="menu-icon fa fa-' . $properties['config']['table']['icon'] . '"></i>&nbsp;&nbsp;' . $title;
+    }
+
     if (isset($options['renderAs']) && $options['renderAs'] === 'plain') {
         echo $properties['dispFieldVal'];
-    } else {
-        // generate related record(s) html link
-        $title = $properties['dispFieldVal'];
-
-        // Special case for entities having an image_src like Users
-        if (Configure::read('Theme.prependAvatars', true) && !empty($properties['entity']['image_src'])) {
-            $title = '<img alt="Thumbnail" src="' . $properties['entity']['image_src'] . '" style="width: 20px; height: 20px;" class="img-circle">&nbsp;&nbsp;' . $title;
-        } elseif (!empty($properties['config']['table']['icon'])) {
-            $title = '<i class="menu-icon fa fa-' . $properties['config']['table']['icon'] . '"></i>&nbsp;&nbsp;' . $title;
-        }
-
+    }
+    elseif (isset($options['renderAs']) && $options['renderAs'] === 'badge') {
+        echo $this->Html->div('btn btn-default btn-xs', $title);
+    }
+    else {
         echo $this->Html->link(
             $title,
             $this->Url->build([


### PR DESCRIPTION
Adjusting `renderAs` options, to allow us to use the general badge of Related FieldHandler, but without the link.
It allows us to prevent the users click on the links that they don't have access to.