### PR TITLE
Method getAlias() on table config returns invalid value (task ##17195)

### DIFF
--- a/src/FieldHandlers/Provider/SelectOptions/ListSelectOptions.php
+++ b/src/FieldHandlers/Provider/SelectOptions/ListSelectOptions.php
@@ -38,7 +38,7 @@ class ListSelectOptions extends AbstractSelectOptions
 
         list($module, $list) = false !== strpos($data, '.') ?
             explode('.', $data, 2) :
-            [$this->config->getTable()->getAlias(), $data ?? ''];
+            [App::shortName(get_class($this->config->getTable()), 'Model/Table', 'Table'), $data ?? ''];
 
         try {
             $result = ModuleRegistry::getModule($module)->getList($list, $flatten, true);


### PR DESCRIPTION
This PR fixes an issue were $this->config->getTable()->getAlias() returns invalid value