### PR TITLE
Skip empty values for combined fields (task #17305)

### DIFF
--- a/src/FieldHandlers/Provider/RenderValue/CombinedRenderer.php
+++ b/src/FieldHandlers/Provider/RenderValue/CombinedRenderer.php
@@ -50,6 +50,10 @@ class CombinedRenderer extends AbstractRenderer
             $result[] = $handler->renderValue($data, $options);
         }
 
-        return implode('&nbsp;', $result);
+        if (empty($result[0])) {
+            return '';
+        }
+
+        return implode('&nbsp;', array_filter($result));
     }
 }

--- a/src/Shell/ImportShell.php
+++ b/src/Shell/ImportShell.php
@@ -569,6 +569,7 @@ class ImportShell extends Shell
 
             // Use string types
             $typeMap = array_combine($lookupFields, array_pad([], count($lookupFields), 'string'));
+            Assert::isArray($typeMap);
 
             // alias lookup fields
             foreach ($lookupFields as $k => $v) {

--- a/webroot/js/pickr.init.js
+++ b/webroot/js/pickr.init.js
@@ -3,9 +3,8 @@
         const pickr = new Pickr({
             el: this,
             useAsButton: true,
-            default: this.value ?? '#000000',
+            "default": (this.value ? this.value : '#000000'),
             theme: 'classic',
-
             swatches: [
                 'rgba(244, 67, 54, 1)',
                 'rgba(233, 30, 99, 1)',


### PR DESCRIPTION
We skip empty values for combined fields, so that to avoid displaying `&nsbp;`.