### PR TITLE
Adjust type attribute to consider MS Office Applications as objects

### DIFF
--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -1,4 +1,4 @@
-<?php
+`<?php
 // get upload limit in bytes
 $uploadLimit = Qobo\Utils\Utility\Convert::valueToBytes(ini_get('upload_max_filesize'));
 
@@ -87,11 +87,37 @@ return [
                 'maxFileSize' => (int)($uploadLimit / 1024),
                 'validateInitialCount' => true,
                 'allowedFileTypes' => [],
+                //Array of types or false to show preview for all
+                'allowedPreviewTypes' => ['image'],
+                'initialPreviewFileType' => 'image',
+                'preferIconicPreview' => false,
+                'previewFileIconSettings' => [
+                    'doc' => '<i class="fa fa-file-word-o text-primary"></i>',
+                    'docx' => '<i class="fa fa-file-word-o text-primary"></i>',
+                    'xls' => '<i class="fa fa-file-excel-o text-success"></i>',
+                    'xlsx' => '<i class="fa fa-file-excel-o text-success"></i>',
+                    'ppt' => '<i class="fa fa-file-powerpoint-o text-danger"></i>',
+                    'pptx' => '<i class="fa fa-file-powerpoint-o text-danger"></i>',
+                    'jpg' => '<i class="fa fa-file-photo-o text-warning"></i>',
+                    'png' => '<i class="fa fa-file-photo-o text-warning"></i>',
+                    'jfif' => '<i class="fa fa-file-photo-o text-warning"></i>',
+                    'pdf' => '<i class="fa fa-file-pdf-o text-danger"></i>',
+                    'zip' => '<i class="fa fa-file-archive-o text-muted"></i>',
+                ],
             ],
             'initialPreviewConfig' => [
                 'url' => "/api/file-storages/delete/",
             ],
             'orderField' => 'order',
+            'previewTypes' => [
+                'application/pdf' => 'pdf'
+                'application/msword' => 'object',
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'object',
+                'application/vnd.ms-excel' => 'object',
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'object',
+                'application/vnd.ms-powerpoint' => 'object',
+                'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'object',
+            ],
         ],
         // Configuration options for the ValidateShell
         'ValidateShell' => [

--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -1,4 +1,4 @@
-`<?php
+<?php
 // get upload limit in bytes
 $uploadLimit = Qobo\Utils\Utility\Convert::valueToBytes(ini_get('upload_max_filesize'));
 

--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -110,7 +110,7 @@ return [
             ],
             'orderField' => 'order',
             'previewTypes' => [
-                'application/pdf' => 'pdf'
+                'application/pdf' => 'pdf',
                 'application/msword' => 'object',
                 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'object',
                 'application/vnd.ms-excel' => 'object',

--- a/src/Template/Element/FieldHandlers/FilesFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/FilesFieldHandler/input.ctp
@@ -51,6 +51,10 @@ if ($value && $entities && $entities->count()) {
             case 'application/vnd.ms-excel':
             //xlsx
             case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+            //ppt
+            case 'application/vnd.ms-powerpoint':
+            //pptx
+            case 'application/vnd.openxmlformats-officedocument.presentationml.presentation':
                 $previewType = 'object';
                 break;
             default:

--- a/src/Template/Element/FieldHandlers/FilesFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/FilesFieldHandler/input.ctp
@@ -25,6 +25,7 @@ $options = [
 ];
 
 $orderField = Configure::read('CsvMigrations.BootstrapFileInput.orderField');
+$previewTypes = Configure::read('CsvMigrations.BootstrapFileInput.previewTypes',[]);
 
 if (isset($config[$field]['orderBy']) && $orderField == $config[$field]['orderBy'] && isset($config[$field]['orderDir'])) {
     $options['data-file-order'] = 1;
@@ -39,28 +40,8 @@ if ($value && $entities && $entities->count()) {
     $files = [];
 
     foreach ($entities as $entity) {
-        switch ($entity->mime_type) {
-            case 'application/pdf':
-                $previewType = 'pdf';
-                break;
-            //doc
-            case 'application/msword':
-            //docx
-            case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-            //xls
-            case 'application/vnd.ms-excel':
-            //xlsx
-            case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-            //ppt
-            case 'application/vnd.ms-powerpoint':
-            //pptx
-            case 'application/vnd.openxmlformats-officedocument.presentationml.presentation':
-                $previewType = 'object';
-                break;
-            default:
-                $previewType = 'image';
-                break;
-        }
+
+        $previewType = isset($previewTypes[$entity->mime_type]) ? $previewTypes[$entity->mime_type] : 'image';
 
         $files[] = [
             'id' => $entity->id,

--- a/src/Template/Element/FieldHandlers/FilesFieldHandler/input.ctp
+++ b/src/Template/Element/FieldHandlers/FilesFieldHandler/input.ctp
@@ -37,13 +37,33 @@ if (isset($config[$field]['limit'])) {
 if ($value && $entities && $entities->count()) {
     $options['data-document-id'] = $value;
     $files = [];
+
     foreach ($entities as $entity) {
+        switch ($entity->mime_type) {
+            case 'application/pdf':
+                $previewType = 'pdf';
+                break;
+            //doc
+            case 'application/msword':
+            //docx
+            case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+            //xls
+            case 'application/vnd.ms-excel':
+            //xlsx
+            case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+                $previewType = 'object';
+                break;
+            default:
+                $previewType = 'image';
+                break;
+        }
+
         $files[] = [
             'id' => $entity->id,
             'path' => $entity->path,
             'size' => $entity->get('filesize'),
             'caption' => h($entity->filename),
-            'type' => ('application/pdf' == $entity->mime_type) ? 'pdf' : 'image',
+            'type' => $previewType,
             'file_type' => $entity->mime_type,
         ];
     }

--- a/webroot/js/fileinput-load.js
+++ b/webroot/js/fileinput-load.js
@@ -3,7 +3,6 @@ $(document).ready(function () {
 
   /* constructor */
     var FileInput = function (files, name, field) {
-        this.html = this.staticHtml;
         this.api_token = api_options.hasOwnProperty('token') ? api_options.token : null;
         this.options = {};
         if (typeof files === 'object') {
@@ -23,22 +22,6 @@ $(document).ready(function () {
 
     //Use this to override setting from config
     FileInput.prototype.defaultOptions = {};
-
-    FileInput.prototype.staticHtml = {
-        previewOtherFile: "<div class='file-preview-text'><h2>" +
-        "<i class='glyphicon glyphicon-file'></i></h2>" +
-        "<a href='%%url%%' target='_blank'>View file</a></div>",
-        img: "<img class='img-responsive' src='%%url%%' alt='img-preview' />",
-        trash: "<i class=\"glyphicon glyphicon-trash\"></i>",
-        icons: {
-            docx: '<i class="fa fa-file-word-o text-primary"></i>',
-            xlsx: '<i class="fa fa-file-excel-o text-success"></i>',
-            pptx: '<i class="fa fa-file-powerpoint-o text-danger"></i>',
-            jpg: '<i class="fa fa-file-photo-o text-warning"></i>',
-            pdf: '<i class="fa fa-file-pdf-o text-danger"></i>',
-            zip: '<i class="fa fa-file-archive-o text-muted"></i>',
-        }
-    };
 
   /**
    * Preview initial preview of the upload field.
@@ -96,7 +79,9 @@ $(document).ready(function () {
                         url: '/api/file-storage/delete/' + file.id,
                         size: file.size,
                         caption: file.caption,
-                        downloadUrl: file.path
+                        type: file.type,
+                        filetype: file.file_type,
+                        downloadUrl: file.path,
                     };
                     filesOptions.push(options);
                 }
@@ -186,7 +171,7 @@ $(document).ready(function () {
                 contentType: 'application/json',
                 headers: {
                     'Authorization': 'Bearer ' + that.api_token
-                },
+                }
             }
         };
 


### PR DESCRIPTION
This PR fixes an issue with fileinput plugin that MS Office Applications were considered as images