### PR TITLE
AutoIncrementFieldValue method doesn't count all records (Task #18485)

### DIFF
--- a/src/Event/Model/AutoIncrementEventListener.php
+++ b/src/Event/Model/AutoIncrementEventListener.php
@@ -78,7 +78,7 @@ class AutoIncrementEventListener implements EventListenerInterface
 
         foreach ($fields as $field => $options) {
             // get max value
-            $query = $table->find('withTrashed');
+            $query = $table->find('withTrashed', ['accessCheck' => false]);
 
             try {
                 $max = $query->select([$field => $query->func()->max((string)$field)])


### PR DESCRIPTION
This PR fixes an issue with the auto-increment field type that during an entity save the maximum value returned of the selected field is without taking into consideration the whole table values but instead only the values that the user has access resulting in duplicate auto increment values in the table